### PR TITLE
Do not emit empty address components in xml output

### DIFF
--- a/xml/helpers.go
+++ b/xml/helpers.go
@@ -48,6 +48,12 @@ func (r *Renderer) outOneOfCr(w io.Writer, outFirst bool, first string, second s
 	}
 }
 
+func (r *Renderer) outTagMaybe(w io.Writer, name string, content string) {
+	if content != "" {
+		r.outTagContent(w, name, content)
+	}
+}
+
 func (r *Renderer) outTagContent(w io.Writer, name string, content string) {
 	io.WriteString(w, name+">")
 	html.EscapeHTML(w, []byte(content))

--- a/xml/title.go
+++ b/xml/title.go
@@ -103,31 +103,31 @@ func (r *Renderer) TitleAuthor(w io.Writer, a mast.Author) {
 		r.outTagContent(w, "<street", street)
 	}
 
-	r.outTagContent(w, "<city", a.Address.Postal.City)
+	r.outTagMaybe(w, "<city", a.Address.Postal.City)
 	for _, city := range a.Address.Postal.Cities {
 		r.outTagContent(w, "<city", city)
 	}
 
-	r.outTagContent(w, "<code", a.Address.Postal.Code)
+	r.outTagMaybe(w, "<code", a.Address.Postal.Code)
 	for _, code := range a.Address.Postal.Codes {
 		r.outTagContent(w, "<code", code)
 	}
 
-	r.outTagContent(w, "<country", a.Address.Postal.Country)
+	r.outTagMaybe(w, "<country", a.Address.Postal.Country)
 	for _, country := range a.Address.Postal.Countries {
 		r.outTagContent(w, "<country", country)
 	}
 
-	r.outTagContent(w, "<region", a.Address.Postal.Region)
+	r.outTagMaybe(w, "<region", a.Address.Postal.Region)
 	for _, region := range a.Address.Postal.Regions {
 		r.outTagContent(w, "<region", region)
 	}
 
 	r.outs(w, "</postal>")
 
-	r.outTagContent(w, "<phone", a.Address.Phone)
-	r.outTagContent(w, "<email", a.Address.Email)
-	r.outTagContent(w, "<uri", a.Address.URI)
+	r.outTagMaybe(w, "<phone", a.Address.Phone)
+	r.outTagMaybe(w, "<email", a.Address.Email)
+	r.outTagMaybe(w, "<uri", a.Address.URI)
 
 	r.outs(w, "</address>")
 	r.outs(w, "</author>")


### PR DESCRIPTION
The online xml2rfc converter at https://xml2rfc.tools.ietf.org/
requires certain XML elements to be non-empty, including various
optional parts of the authors' addresses. So this change skips
the whole of the optional element if its contents are empty.
