### PR TITLE
fixed reading 0 size file crashing

### DIFF
--- a/mparser/hook.go
+++ b/mparser/hook.go
@@ -49,6 +49,9 @@ func (i Initial) ReadInclude(from, file string, address []byte) []byte {
 		log.Printf("Failure to parse address for %q: %q (from %q)", path, err, filepath.Join(from, "*"))
 		return nil
 	}
+	if len(data) == 0 {
+		return data
+	}
 	if data[len(data)-1] != '\n' {
 		data = append(data, '\n')
 	}


### PR DESCRIPTION
It will be crashed when including an empty file.

> panic: runtime error: index out of range
> 
> goroutine 1 [running]:
> github.com/mmarkdown/mmark/mparser.Initial.ReadInclude(0x0, 0xc000018740, 0x2b, 0x0, 0x0, 0xc000012820, 0x17, 0x0, 0x0, 0x0, ...)
> 	/home/mikespook/golang/3rdpkg/src/github.com/mmarkdown/mmark/mparser/hook.go:52 +0x62d
> github.com/mmarkdown/mmark/mparser.Initial.ReadInclude-fm(0x0, 0x0, 0xc000012820, 0x17, 0x0, 0x0, 0x0, 0x17, 0xc000012820, 0xc0000c9918)

It's because the `len(data)` is 0 when loading an empty file. Therefore, `len(data)-1` is `-1` which is an impossible range to a slice.