### PR TITLE
allow heading-id syntax in caption

### DIFF
--- a/Syntax.md
+++ b/Syntax.md
@@ -388,6 +388,17 @@ And for a quote:
 
      Quote: https://example.com, Napoleon Bonaparte
 
+A caption can potentially contain a "heading ID": `{#id}` as the *last* text in the caption. If this
+is found that ID is used as the ID for the entire figure:
+
+~~~
+Name    | Age
+--------|-----:
+Bob     | 27
+Alice   | 23
+Table: This is the table caption. {#ages}
+~~~
+
 ### Asides
 
 Any text prefixed with `A>` will become an

--- a/testdata/caption-id.md
+++ b/testdata/caption-id.md
@@ -1,0 +1,5 @@
+Name    | Age
+--------|------
+Bob     | 27
+Alice   | 23
+Table: This is a proper table caption. {#data_types}

--- a/testdata/caption-id.xml
+++ b/testdata/caption-id.xml
@@ -1,0 +1,20 @@
+<table anchor="data-types"><name>This is a proper table caption. </name>
+<thead>
+<tr>
+<th>Name</th>
+<th>Age</th>
+</tr>
+</thead>
+
+<tbody>
+<tr>
+<td>Bob</td>
+<td>27</td>
+</tr>
+
+<tr>
+<td>Alice</td>
+<td>23</td>
+</tr>
+</tbody>
+</table>

--- a/testdata/code-caption-id.md
+++ b/testdata/code-caption-id.md
@@ -1,0 +1,4 @@
+~~~
+println("GO")
+~~~
+Figure: This is a proper caption. {#golang}

--- a/testdata/code-caption-id.xml
+++ b/testdata/code-caption-id.xml
@@ -1,0 +1,5 @@
+<figure anchor="golang"<name>This is a proper caption. </name>
+<artwork>println(&quot;GO&quot;)
+</artwork>
+</figure>
+

--- a/xml/renderer.go
+++ b/xml/renderer.go
@@ -503,7 +503,14 @@ func (r *Renderer) captionFigure(w io.Writer, captionFigure *ast.CaptionFigure, 
 		return
 	}
 
-	r.outs(w, "<figure>")
+	if captionFigure.HeadingID != "" {
+		mast.AttributeInit(captionFigure)
+		captionFigure.Attribute.ID = []byte(captionFigure.HeadingID)
+	}
+
+	r.outs(w, "<figure")
+	r.outAttr(w, html.BlockAttrs(captionFigure))
+
 	// Now render the caption and then *remove* it from the tree.
 	for _, child := range captionFigure.GetChildren() {
 		if caption, ok := child.(*ast.Caption); ok {
@@ -522,14 +529,18 @@ func (r *Renderer) table(w io.Writer, tab *ast.Table, entering bool) {
 		r.outs(w, "</table>")
 		return
 	}
+	captionFigure, isCaptionFigure := tab.Parent.(*ast.CaptionFigure)
+	if isCaptionFigure && captionFigure.HeadingID != "" {
+		mast.AttributeInit(tab)
+		tab.Attribute.ID = []byte(captionFigure.HeadingID)
+	}
 
 	tag := tagWithAttributes("<table", html.BlockAttrs(tab))
 	r.outs(w, tag)
 
 	// Now render the caption if our parent is a ast.CaptionFigure
 	// and then *remove* it from the tree.
-	captionFigure, ok := tab.Parent.(*ast.CaptionFigure)
-	if !ok {
+	if !isCaptionFigure {
 		return
 	}
 	for _, child := range captionFigure.GetChildren() {
@@ -549,6 +560,11 @@ func (r *Renderer) blockQuote(w io.Writer, block *ast.BlockQuote, entering bool)
 		r.outs(w, "</blockquote>")
 		return
 	}
+	captionFigure, isCaptionFigure := block.Parent.(*ast.CaptionFigure)
+	if isCaptionFigure && captionFigure.HeadingID != "" {
+		mast.AttributeInit(block)
+		block.Attribute.ID = []byte(captionFigure.HeadingID)
+	}
 
 	r.outs(w, "<blockquote")
 	r.outAttr(w, html.BlockAttrs(block))
@@ -556,8 +572,7 @@ func (r *Renderer) blockQuote(w io.Writer, block *ast.BlockQuote, entering bool)
 
 	// Now render the caption if our parent is a ast.CaptionFigure
 	// and then *remove* it from the tree.
-	captionFigure, ok := block.Parent.(*ast.CaptionFigure)
-	if !ok {
+	if !isCaptionFigure {
 		return
 	}
 	for _, child := range captionFigure.GetChildren() {

--- a/xml2/renderer.go
+++ b/xml2/renderer.go
@@ -560,6 +560,10 @@ func (r *Renderer) captionFigure(w io.Writer, captionFigure *ast.CaptionFigure, 
 		r.outs(w, "</figure>\n")
 		return
 	}
+	if captionFigure.HeadingID != "" {
+		mast.AttributeInit(captionFigure)
+		captionFigure.Attribute.ID = []byte(captionFigure.HeadingID)
+	}
 
 	r.outs(w, "<figure")
 	r.outAttr(w, html.BlockAttrs(captionFigure))
@@ -586,13 +590,19 @@ func (r *Renderer) table(w io.Writer, tab *ast.Table, entering bool) {
 		r.outs(w, "</texttable>")
 		return
 	}
+	captionFigure, inFigure := tab.Parent.(*ast.CaptionFigure)
+	if inFigure {
+		if captionFigure.HeadingID != "" {
+			mast.AttributeInit(tab)
+			tab.Attribute.ID = []byte(captionFigure.HeadingID)
+		}
+	}
 
 	r.outs(w, "<texttable")
 	r.outAttr(w, html.BlockAttrs(tab))
 	// Now render the caption if our parent is a ast.CaptionFigure
 	// and then *remove* it from the tree.
-	captionFigure, ok := tab.Parent.(*ast.CaptionFigure)
-	if !ok {
+	if !inFigure {
 		r.outs(w, `>`)
 		return
 	}


### PR DESCRIPTION
Supported by mmark1, port it to mmark2 as well (to ease transition and it's a nice feature actually)

Signed-off-by: Miek Gieben <miek@miek.nl>