### PR TITLE
Indent list with 4 spaces

### DIFF
--- a/render/markdown/helpers.go
+++ b/render/markdown/helpers.go
@@ -124,13 +124,13 @@ func listPrefixLength(list *ast.List, start int) int {
 	numChild := len(list.Children) + start
 	switch {
 	case numChild < 10:
-		return 3
-	case numChild < 100:
 		return 4
-	case numChild < 1000:
+	case numChild < 100:
 		return 5
+	case numChild < 1000:
+		return 6
 	}
-	return 6 // bit of a ridicules list
+	return 7 // bit of a ridicules list
 }
 
 func Space(length int) []byte { return bytes.Repeat([]byte(" "), length) }

--- a/render/markdown/renderer.go
+++ b/render/markdown/renderer.go
@@ -249,7 +249,7 @@ func (r *Renderer) list(w io.Writer, list *ast.List, entering bool) {
 		if list.ListFlags&ast.ListTypeOrdered != 0 {
 			r.push(Space(l))
 		} else {
-			r.push(Space(3))
+			r.push(Space(4))
 		}
 		return
 	}
@@ -339,7 +339,7 @@ func (r *Renderer) tableCell(w io.Writer, tableCell *ast.TableCell, entering boo
 			r.cellStart = buf.Len() + 1
 		}
 		if r.col > 0 {
-			r.out(w, Space1)
+			r.out(w, Space(1))
 		}
 		return
 	}
@@ -349,7 +349,7 @@ func (r *Renderer) tableCell(w io.Writer, tableCell *ast.TableCell, entering boo
 		cur = buf.Len()
 	}
 	size := r.colWidth[r.col]
-	fill := bytes.Repeat(Space1, size-(cur-r.cellStart))
+	fill := bytes.Repeat(Space(1), size-(cur-r.cellStart))
 	r.out(w, fill)
 	if r.col == len(r.colWidth)-1 {
 		r.endline(w)
@@ -788,7 +788,6 @@ func (r *Renderer) RenderFooter(w io.Writer, _ ast.Node) {
 }
 
 var (
-	Space1 = Space(1)
-	Aside  = []byte("A> ")
-	Quote  = []byte("> ")
+	Aside = []byte("A> ")
+	Quote = []byte("> ")
 )

--- a/testdata/markdown/attr-list-in-def-list.fmt
+++ b/testdata/markdown/attr-list-in-def-list.fmt
@@ -1,26 +1,26 @@
 Option Length
 
-:  8-bit unsigned integer. The length of the option in octets (excluding the Option Type and Option
-   Length fields). The value **MUST** be greater than 0.
+:   8-bit unsigned integer. The length of the option in octets (excluding the Option Type and Option
+    Length fields). The value **MUST** be greater than 0.
 
 SRO Param
 
-:  8-bit identifier indicating Scenic Routing parameters encoded as a bit string.
+:   8-bit identifier indicating Scenic Routing parameters encoded as a bit string.
 
-   ~~~
-   +-+-+-+-+-+-+-+-+
-   | SR A W AA X Y |
-   +-+-+-+-+-+-+-+-+
-   ~~~
-   Figure: SRO Param Bit String Layout
+    ~~~
+    +-+-+-+-+-+-+-+-+
+    | SR A W AA X Y |
+    +-+-+-+-+-+-+-+-+
+    ~~~
+    Figure: SRO Param Bit String Layout
 
-   {empty="true" style="empty"}
-   *  00 - Scenic Routing **MUST NOT** be used for this packet.
+    {empty="true" style="empty"}
+    *   00 - Scenic Routing **MUST NOT** be used for this packet.
 
-   *  01 - Scenic Routing **MIGHT** be used for this packet.
+    *   01 - Scenic Routing **MIGHT** be used for this packet.
 
-   *  10 - Scenic Routing **SHOULD** be used for this packet.
+    *   10 - Scenic Routing **SHOULD** be used for this packet.
 
-   *  11 - Scenic Routing **MUST** be used for this packet.
+    *   11 - Scenic Routing **MUST** be used for this packet.
 
-   The following BIT (A) defines if Avian IP Carriers should be used.
+    The following BIT (A) defines if Avian IP Carriers should be used.

--- a/testdata/markdown/def-list-para.fmt
+++ b/testdata/markdown/def-list-para.fmt
@@ -1,12 +1,12 @@
 Option Type
 
-:  8-bit identifier of the type of option. The option identifier
+:   8-bit identifier of the type of option. The option identifier
 
-   The highest-order two bits are set to 00 so any node not implementing Scenic Routing will skip
-   over this option and continue processing the header. The third-highest-order bit
+    The highest-order two bits are set to 00 so any node not implementing Scenic Routing will skip
+    over this option and continue processing the header. The third-highest-order bit
 
-   indicates that the SRO does not change en route to the packet's final destination.
+    indicates that the SRO does not change en route to the packet's final destination.
 
 Option Length
 
-:  8-bit unsigned integer. The length of the option in octets
+:   8-bit unsigned integer. The length of the option in octets

--- a/testdata/markdown/def-list.fmt
+++ b/testdata/markdown/def-list.fmt
@@ -1,18 +1,18 @@
 module rule:
 
-:  controls access for definitions in a specific YANG module, identified by its name.
+:   controls access for definitions in a specific YANG module, identified by its name.
 
 protocol operation rule:
 
-:  controls access for a specific protocol operation, identified by its YANG module and name.
+:   controls access for a specific protocol operation, identified by its YANG module and name.
 
 data node rule:
 
-:  controls access for a specific data node and its descendants, identified by its path location
-   within the conceptual XML document for the data node.
+:   controls access for a specific data node and its descendants, identified by its path location
+    within the conceptual XML document for the data node.
 
 notification rule:
 
-:  controls access for a specific notification event type, identified by its YANG module and name.
+:   controls access for a specific notification event type, identified by its YANG module and name.
 
 More.

--- a/testdata/markdown/epigraph-list.fmt
+++ b/testdata/markdown/epigraph-list.fmt
@@ -1,7 +1,7 @@
 {.epigraph}
-> *  Parallelism is about performance.
+> *   Parallelism is about performance.
 >
-> *  Concurrency is about program design.
+> *   Concurrency is about program design.
 >
 > ********
 >

--- a/testdata/markdown/header-after-list.fmt
+++ b/testdata/markdown/header-after-list.fmt
@@ -1,6 +1,5 @@
-*  item1
+*   item1
 
-*  item2
+*   item2
 
 # Introduction
-

--- a/testdata/markdown/list-in-aside-para.fmt
+++ b/testdata/markdown/list-in-aside-para.fmt
@@ -1,9 +1,9 @@
-A> *  this is a list more rehjsh dhsjd hsj dhsjds hdjs dhsjdshjd sdhsj dshjdsh dsjd shjdshdsjdshd
-A>    sdhsj
+A> *   this is a list more rehjsh dhsjd hsj dhsjds hdjs dhsjdshjd sdhsj dshjdsh dsjd shjdshdsjdshd
+A>     sdhsj
 A>
-A> *  more list
+A> *   more list
 A>
-A> *  even more list
+A> *   even more list
 A>
 
 And another paragraph.

--- a/testdata/markdown/list-in-aside.fmt
+++ b/testdata/markdown/list-in-aside.fmt
@@ -1,7 +1,7 @@
-A> *  this is a list more rehjsh dhsjd hsj dhsjds hdjs dhsjdshjd sdhsj dshjdsh dsjd shjdshdsjdshd
-A>    sdhsj
+A> *   this is a list more rehjsh dhsjd hsj dhsjds hdjs dhsjdshjd sdhsj dshjdsh dsjd shjdshdsjdshd
+A>     sdhsj
 A>
-A> *  more list
+A> *   more list
 A>
-A> *  even more list
+A> *   even more list
 A>

--- a/testdata/markdown/list-in-quote.fmt
+++ b/testdata/markdown/list-in-quote.fmt
@@ -1,9 +1,9 @@
-> *  this is a list more rehjsh dhsjd hsj dhsjds hdjs dhsjdshjd sdhsj dshjdsh dsjd shjdshdsjdshd
->    sdhsj
+> *   this is a list more rehjsh dhsjd hsj dhsjds hdjs dhsjdshjd sdhsj dshjdsh dsjd shjdshdsjdshd
+>     sdhsj
 >
-> *  more list
+> *   more list
 >
-> *  even more list
+> *   even more list
 >
 
 More text.

--- a/testdata/markdown/list-indent.fmt
+++ b/testdata/markdown/list-indent.fmt
@@ -1,31 +1,31 @@
-1.  hallo
+1.   hallo
 
-2.  hallo
+2.   hallo
 
-3.  hallo
+3.   hallo
 
-4.  hallo
+4.   hallo
 
-5.  hallo
+5.   hallo
 
-6.  hallo
+6.   hallo
 
-7.  hallo
+7.   hallo
 
-    1. hallo
+     1.  hallo
 
-    2. hallo
+     2.  hallo
 
-    3. hallo
+     3.  hallo
 
-    4. hallo
+     4.  hallo
 
-8.  hallo
+8.   hallo
 
-9.  hallo
+9.   hallo
 
-10. hallo
+10.  hallo
 
-11. hallo
+11.  hallo
 
-12. hallo
+12.  hallo

--- a/testdata/markdown/list-para.fmt
+++ b/testdata/markdown/list-para.fmt
@@ -1,8 +1,8 @@
-*  8-bit identifier of the type of option. The option identifier
+*   8-bit identifier of the type of option. The option identifier
 
-   The highest-order two bits are set to 00 so any node not implementing Scenic Routing will skip
-   over this option and continue processing the header. The third-highest-order bit
+    The highest-order two bits are set to 00 so any node not implementing Scenic Routing will skip
+    over this option and continue processing the header. The third-highest-order bit
 
-   indicates that the SRO does not change en route to the packet's final destination.
+    indicates that the SRO does not change en route to the packet's final destination.
 
-*  Option Length 8-bit unsigned integer. The length of the option in octets
+*   Option Length 8-bit unsigned integer. The length of the option in octets

--- a/testdata/markdown/list-paragraph.fmt
+++ b/testdata/markdown/list-paragraph.fmt
@@ -1,9 +1,9 @@
-*  item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1
-   item1 item1 item1 item1 item1 item1 item1 item1
+*   item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1
+    item1 item1 item1 item1 item1 item1 item1 item1
 
-*  item2 item2
+*   item2 item2
 
-*  item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3
-   item3 item3 item3 item3 item3 item3
+*   item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3
+    item3 item3 item3 item3 item3 item3
 
 More text.

--- a/testdata/markdown/list-start-9.fmt
+++ b/testdata/markdown/list-start-9.fmt
@@ -1,7 +1,7 @@
-9.  hallo
+9.   hallo
 
-10. hallo
+10.  hallo
 
-11. hallo
+11.  hallo
 
-12. hallo
+12.  hallo

--- a/testdata/markdown/list-start.fmt
+++ b/testdata/markdown/list-start.fmt
@@ -1,3 +1,3 @@
-4. This is a list
+4.  This is a list
 
-5. Another item.
+5.  Another item.

--- a/testdata/markdown/list.fmt
+++ b/testdata/markdown/list.fmt
@@ -1,8 +1,7 @@
-*  item1
+*   item1
 
-*  item2
+*   item2
 
-*  item3
+*   item3
 
-*  item4
-
+*   item4

--- a/testdata/markdown/sub-list-ending.fmt
+++ b/testdata/markdown/sub-list-ending.fmt
@@ -1,11 +1,11 @@
-1. Process all rule-list entries
+1.  Process all rule-list entries
 
-2. For each rule-list entry found
+2.  For each rule-list entry found
 
-   *  Item2
+    *   Item2
 
-   *  Item3
+    *   Item3
 
-   *  Item4
+    *   Item4
 
-3. If a matching rule is found
+3.  If a matching rule is found

--- a/testdata/markdown/sub-list-ending2.fmt
+++ b/testdata/markdown/sub-list-ending2.fmt
@@ -1,11 +1,11 @@
-1. Process all rule-list entries
+1.  Process all rule-list entries
 
-2. For each rule-list entry found
+2.  For each rule-list entry found
 
-   *  Item2
+    *   Item2
 
-   *  Item3
+    *   Item3
 
-   *  Item4
+    *   Item4
 
 Paragraph.

--- a/testdata/markdown/subfigure.fmt
+++ b/testdata/markdown/subfigure.fmt
@@ -1,8 +1,8 @@
-*  `len(slice) == n`
+*   `len(slice) == n`
 
-*  `cap(slice) == m`
+*   `cap(slice) == m`
 
-*  `len(array) == cap(array) == m`
+*   `len(array) == cap(array) == m`
 
 !---
 ![Array versus slice](fig/array-vs-slice.png)\


### PR DESCRIPTION
This is done to recognize any block level elements correctly. We could
only do it if we detect these in a list, but this complicates the
indentation code even further, just going from 3 to 4 makes things
slightly simpler, but does make it quite spacious.