### PR TITLE
Indent lists

### DIFF
--- a/render/markdown/renderer.go
+++ b/render/markdown/renderer.go
@@ -217,19 +217,20 @@ func (r *Renderer) paragraph(w io.Writer, para *ast.Paragraph, entering bool) {
 
 			list.Start++
 		case x&ast.ListTypeTerm != 0:
+			// This does too much.
 			indented = indented[plen+r.prefix.peek():] // remove prefix.
 		case x&ast.ListTypeDefinition != 0:
 			indented[plen+0] = ':'
 			indented[plen+1] = ' '
 			indented[plen+2] = ' '
 		default:
+			indented[plen+0] = ' '
 			if r.listLevel%2 == 0 {
-				indented[plen+0] = '*'
+				indented[plen+1] = '*'
 			} else {
-				indented[plen+0] = '-'
+				indented[plen+1] = '-'
 			}
 
-			indented[plen+1] = ' '
 			indented[plen+2] = ' '
 		}
 	}

--- a/testdata/markdown/attr-list-in-def-list.fmt
+++ b/testdata/markdown/attr-list-in-def-list.fmt
@@ -15,12 +15,12 @@ SRO Param
     Figure: SRO Param Bit String Layout
 
     {empty="true" style="empty"}
-    *   00 - Scenic Routing **MUST NOT** be used for this packet.
+     *  00 - Scenic Routing **MUST NOT** be used for this packet.
 
-    *   01 - Scenic Routing **MIGHT** be used for this packet.
+     *  01 - Scenic Routing **MIGHT** be used for this packet.
 
-    *   10 - Scenic Routing **SHOULD** be used for this packet.
+     *  10 - Scenic Routing **SHOULD** be used for this packet.
 
-    *   11 - Scenic Routing **MUST** be used for this packet.
+     *  11 - Scenic Routing **MUST** be used for this packet.
 
     The following BIT (A) defines if Avian IP Carriers should be used.

--- a/testdata/markdown/def-list.md
+++ b/testdata/markdown/def-list.md
@@ -1,14 +1,14 @@
 module rule:
-:   controls access for definitions in a specific YANG module, identified by its name.
+:  controls access for definitions in a specific YANG module, identified by its name.
 
 protocol operation rule:
-:   controls access for a specific protocol operation, identified by its YANG module and name.
+:  controls access for a specific protocol operation, identified by its YANG module and name.
 
 data node rule:
-:   controls access for a specific data node and its descendants, identified by its path location
+:  controls access for a specific data node and its descendants, identified by its path location
 within the conceptual XML document for the data node.
 
 notification rule:
-:   controls access for a specific notification event type, identified by its YANG module and name.
+:  controls access for a specific notification event type, identified by its YANG module and name.
 
 More.

--- a/testdata/markdown/epigraph-list.fmt
+++ b/testdata/markdown/epigraph-list.fmt
@@ -1,7 +1,7 @@
 {.epigraph}
-> *   Parallelism is about performance.
+>  *  Parallelism is about performance.
 >
-> *   Concurrency is about program design.
+>  *  Concurrency is about program design.
 >
 > ********
 >

--- a/testdata/markdown/header-after-list.fmt
+++ b/testdata/markdown/header-after-list.fmt
@@ -1,5 +1,5 @@
-*   item1
+ *  item1
 
-*   item2
+ *  item2
 
 # Introduction

--- a/testdata/markdown/list-in-aside-para.fmt
+++ b/testdata/markdown/list-in-aside-para.fmt
@@ -1,9 +1,9 @@
-A> *   this is a list more rehjsh dhsjd hsj dhsjds hdjs dhsjdshjd sdhsj dshjdsh dsjd shjdshdsjdshd
+A>  *  this is a list more rehjsh dhsjd hsj dhsjds hdjs dhsjdshjd sdhsj dshjdsh dsjd shjdshdsjdshd
 A>     sdhsj
 A>
-A> *   more list
+A>  *  more list
 A>
-A> *   even more list
+A>  *  even more list
 A>
 
 And another paragraph.

--- a/testdata/markdown/list-in-aside.fmt
+++ b/testdata/markdown/list-in-aside.fmt
@@ -1,7 +1,7 @@
-A> *   this is a list more rehjsh dhsjd hsj dhsjds hdjs dhsjdshjd sdhsj dshjdsh dsjd shjdshdsjdshd
+A>  *  this is a list more rehjsh dhsjd hsj dhsjds hdjs dhsjdshjd sdhsj dshjdsh dsjd shjdshdsjdshd
 A>     sdhsj
 A>
-A> *   more list
+A>  *  more list
 A>
-A> *   even more list
+A>  *  even more list
 A>

--- a/testdata/markdown/list-in-quote.fmt
+++ b/testdata/markdown/list-in-quote.fmt
@@ -1,9 +1,9 @@
-> *   this is a list more rehjsh dhsjd hsj dhsjds hdjs dhsjdshjd sdhsj dshjdsh dsjd shjdshdsjdshd
+>  *  this is a list more rehjsh dhsjd hsj dhsjds hdjs dhsjdshjd sdhsj dshjdsh dsjd shjdshdsjdshd
 >     sdhsj
 >
-> *   more list
+>  *  more list
 >
-> *   even more list
+>  *  even more list
 >
 
 More text.

--- a/testdata/markdown/list-para.fmt
+++ b/testdata/markdown/list-para.fmt
@@ -1,8 +1,8 @@
-*   8-bit identifier of the type of option. The option identifier
+ *  8-bit identifier of the type of option. The option identifier
 
     The highest-order two bits are set to 00 so any node not implementing Scenic Routing will skip
     over this option and continue processing the header. The third-highest-order bit
 
     indicates that the SRO does not change en route to the packet's final destination.
 
-*   Option Length 8-bit unsigned integer. The length of the option in octets
+ *  Option Length 8-bit unsigned integer. The length of the option in octets

--- a/testdata/markdown/list-paragraph.fmt
+++ b/testdata/markdown/list-paragraph.fmt
@@ -1,9 +1,9 @@
-*   item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1
+ *  item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1 item1
     item1 item1 item1 item1 item1 item1 item1 item1
 
-*   item2 item2
+ *  item2 item2
 
-*   item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3
+ *  item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3 item3
     item3 item3 item3 item3 item3 item3
 
 More text.

--- a/testdata/markdown/list.fmt
+++ b/testdata/markdown/list.fmt
@@ -1,7 +1,7 @@
-*   item1
+ *  item1
 
-*   item2
+ *  item2
 
-*   item3
+ *  item3
 
-*   item4
+ *  item4

--- a/testdata/markdown/sub-list-ending.fmt
+++ b/testdata/markdown/sub-list-ending.fmt
@@ -2,10 +2,10 @@
 
 2.  For each rule-list entry found
 
-    *   Item2
+     *  Item2
 
-    *   Item3
+     *  Item3
 
-    *   Item4
+     *  Item4
 
 3.  If a matching rule is found

--- a/testdata/markdown/sub-list-ending2.fmt
+++ b/testdata/markdown/sub-list-ending2.fmt
@@ -2,10 +2,10 @@
 
 2.  For each rule-list entry found
 
-    *   Item2
+     *  Item2
 
-    *   Item3
+     *  Item3
 
-    *   Item4
+     *  Item4
 
 Paragraph.

--- a/testdata/markdown/subfigure.fmt
+++ b/testdata/markdown/subfigure.fmt
@@ -1,8 +1,8 @@
-*   `len(slice) == n`
+ *  `len(slice) == n`
 
-*   `cap(slice) == m`
+ *  `cap(slice) == m`
 
-*   `len(array) == cap(array) == m`
+ *  `len(array) == cap(array) == m`
 
 !---
 ![Array versus slice](fig/array-vs-slice.png)\


### PR DESCRIPTION
Indent unordered and term definition with a single space. Just makes
them stand out a little more and means we only have 2 spaces between
list char and the text.

For numbered lists and def. lists there is not a lot of space to do this
and they standout more because of the numbering and colon use. Also def.
are not detected if the colon is not in the first column.

Signed-off-by: Miek Gieben <miek@miek.nl>