### PR TITLE
Reference: allow multiple authors

### DIFF
--- a/mast/reference/reference.go
+++ b/mast/reference/reference.go
@@ -19,9 +19,9 @@ type Date struct {
 
 // Front the reference <front>.
 type Front struct {
-	Title  string `xml:"title"`
-	Author Author `xml:"author"`
-	Date   Date   `xml:"date"`
+	Title   string   `xml:"title"`
+	Authors []Author `xml:"author"`
+	Date    Date     `xml:"date"`
 }
 
 // Format is the reference <format>.

--- a/render/mhtml/hook.go
+++ b/render/mhtml/hook.go
@@ -103,7 +103,9 @@ func bibliographyItem(w io.Writer, bib *mast.BibliographyItem, entering bool) {
 	if bib.Reference == nil {
 		return
 	}
-	io.WriteString(w, `<span class="bibliography-author">`+bib.Reference.Front.Author.Fullname+"</span>\n")
+	for _, author := range bib.Reference.Front.Authors {
+		io.WriteString(w, `<span class="bibliography-author">`+author.Fullname+"</span>\n")
+	}
 	io.WriteString(w, `<span class="bibliography-title">`+bib.Reference.Front.Title+"</span>\n")
 	if bib.Reference.Format != nil && bib.Reference.Format.Target != "" {
 		io.WriteString(w, `<a class="bliography-target" href="`+bib.Reference.Format.Target+"\">"+bib.Reference.Format.Target+"</a>\n")


### PR DESCRIPTION
Multiple authors in a reference were not parsed correctly, fix the
reference struct to make the author a slice.

Fixes: #53