### PR TITLE
Add more author elements to the reference struct

### DIFF
--- a/mast/reference/reference.go
+++ b/mast/reference/reference.go
@@ -5,9 +5,39 @@ import "encoding/xml"
 
 // Author is the reference author.
 type Author struct {
-	Fullname string `xml:"fullname,attr"`
-	Initials string `xml:"initials,attr"`
-	Surname  string `xml:"surname,attr"`
+	Fullname     string        `xml:"fullname,attr,omitempty"`
+	Initials     string        `xml:"initials,attr,omitempty"`
+	Surname      string        `xml:"surname,attr,omitempty"`
+	Role         string        `xml:"role,attr,omitempty"`
+	Organization *Organization `xml:"organization,omitempty"`
+	Address      *Address      `xml:"address,omitempty"`
+}
+
+type Organization struct {
+	Abbrev string `xml:"organization,attr,omitempty"`
+}
+
+// this is copied from ../title.go; it might make sense to unify them, both especially, it we
+// want to allow reference to be given in TOML as well. See #55.
+// Author denotes an RFC author.
+
+// Address denotes the address of an RFC author.
+type Address struct {
+	Phone  string        `xml:"phone,omitempty"`
+	Email  string        `xml:"email,omitempty"`
+	URI    string        `xml:"uri,omitempty"`
+	Postal AddressPostal `xml:"postal,omitempty"`
+}
+
+// AddressPostal denotes the postal address of an RFC author.
+type AddressPostal struct {
+	PostalLine []string `xml:"postalline,omitempty"`
+
+	Streets   []string `xml:"street,omitempty"`
+	Cities    []string `xml:"city,omitempty"`
+	Codes     []string `xml:"code,omitempty"`
+	Countries []string `xml:"country,omitempty"`
+	Regions   []string `xml:"region,omitempty"`
 }
 
 // Date is the reference date.
@@ -20,11 +50,11 @@ type Date struct {
 // Front the reference <front>.
 type Front struct {
 	Title   string   `xml:"title"`
-	Authors []Author `xml:"author"`
+	Authors []Author `xml:"author,omitempty"`
 	Date    Date     `xml:"date"`
 }
 
-// Format is the reference <format>.
+// Format is the reference <format>. This is deprecated in RFC 7991, see Section 3.3.
 type Format struct {
 	Type   string `xml:"type,attr,omitempty"`
 	Target string `xml:"target,attr"`
@@ -36,4 +66,5 @@ type Reference struct {
 	Anchor  string   `xml:"anchor,attr"`
 	Front   Front    `xml:"front"`
 	Format  *Format  `xml:"format,omitempty"`
+	Target  string   `xml:"target,attr"`
 }

--- a/mast/reference/reference_test.go
+++ b/mast/reference/reference_test.go
@@ -1,0 +1,34 @@
+package reference
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestReferenceOrganization(t *testing.T) {
+	in := []byte(`<reference anchor='IANA' target='https://www.iana.org/assignments/media-types/media-types.xhtml'>
+    <front>
+        <title abbrev='IANA'>IANA Media Types</title>
+        <author>
+            <organization>IANA</organization>
+        </author>
+        <date month='February' year='2019'/>
+    </front>
+</reference>
+`)
+	expect := `<reference anchor="IANA" target="https://www.iana.org/assignments/media-types/media-types.xhtml"><front><title>IANA Media Types</title><author><organization></organization></author><date year="2019" month="February"></date></front></reference>`
+
+	var x Reference
+	if err := xml.Unmarshal(in, &x); err != nil {
+		t.Errorf("failed to unmarshal reference: %s: %s", in, err)
+	}
+	out, err := xml.Marshal(x)
+	if err != nil {
+		t.Errorf("failed to marshal reference: %s", err)
+	}
+	str := string(out)
+
+	if str != expect {
+		t.Errorf("expected\n%s\ngot\n%s", expect, str)
+	}
+}


### PR DESCRIPTION
This structure was incomplete; which doesn't matter if you just
reference RFCs or IDs, but does if you manually add them. Complete the
struct and add a little test.

Fixes: #61