### PR TITLE
Add missing organization value in organization struct. Rename Abbrev attribute to "abbrev" to match RFC 7749.

### DIFF
--- a/mast/reference/reference.go
+++ b/mast/reference/reference.go
@@ -15,6 +15,7 @@ type Author struct {
 
 type Organization struct {
 	Abbrev string `xml:"organization,attr,omitempty"`
+	Value  string `xml:",chardata"`
 }
 
 // this is copied from ../title.go; it might make sense to unify them, both especially, it we

--- a/mast/reference/reference.go
+++ b/mast/reference/reference.go
@@ -14,7 +14,7 @@ type Author struct {
 }
 
 type Organization struct {
-	Abbrev string `xml:"organization,attr,omitempty"`
+	Abbrev string `xml:"abbrev,attr,omitempty"`
 	Value  string `xml:",chardata"`
 }
 

--- a/mast/reference/reference_test.go
+++ b/mast/reference/reference_test.go
@@ -16,7 +16,7 @@ func TestReferenceOrganization(t *testing.T) {
     </front>
 </reference>
 `)
-	expect := `<reference anchor="IANA" target="https://www.iana.org/assignments/media-types/media-types.xhtml"><front><title>IANA Media Types</title><author><organization></organization></author><date year="2019" month="February"></date></front></reference>`
+	expect := `<reference anchor="IANA" target="https://www.iana.org/assignments/media-types/media-types.xhtml"><front><title>IANA Media Types</title><author><organization>IANA</organization></author><date year="2019" month="February"></date></front></reference>`
 
 	var x Reference
 	if err := xml.Unmarshal(in, &x); err != nil {


### PR DESCRIPTION
The Organization struct had two issues: one was the name of the "abbrev" attribute was incorrect; the other was the missing value in <organization>value</organization>.

This fixes #63 