### PR TITLE
xml: images: use alt text for type attribute

### DIFF
--- a/Syntax.md
+++ b/Syntax.md
@@ -169,8 +169,10 @@ Footnotes:
 
 Images:
 :   Images are supported (but for text output only(?) SVG graphcs are allowed. We convert this to
-    an `<artwork>` with `src` set to the image URL of path. I.e. `![alt](img.jpg "title")` becomes
-    `<artwork src="img.jpg" alt="alt" name="title"/>`.
+    an `<artwork>` with `src` set to the image URL of path. I.e. `![svg](img.svg "title")` becomes
+    `<artwork src="img.svg" type="svg" name="title"/>`. Note the first `svg` (the alt text) is used
+    as the `type=` attribute. Also note that an image like this will be wrapped in `<t>` which is
+    not allowed in RFC 7991 syntax. So to make this fully work you need to the image in a subfigure.
 
 Horizontal Line:
 :   Outputs a paragraph with 60 dashes `-`.
@@ -179,6 +181,9 @@ Comments:
 :   HTML comments are detected and translated into `<cref>`s.
 
 ### XML RFC 7749 Output
+
+When the RFC editor drops support for this format it will be removed from Mmark as well. This is
+expected to happen in 2019.
 
 Title Block:
 :   Identical to RFC 7991, Mmark will take care to translate this into something xml2rfc (v2) can

--- a/render/xml/renderer.go
+++ b/render/xml/renderer.go
@@ -462,9 +462,9 @@ func (r *Renderer) image(w io.Writer, node *ast.Image, entering bool) {
 func (r *Renderer) imageEnter(w io.Writer, image *ast.Image) {
 	dest := image.Destination
 	r.outs(w, `<artwork src="`)
-	// type= will be the extension of dest.
+	// type= will be the alt text
 	html.EscapeHTML(w, dest)
-	r.outs(w, `" alt="`)
+	r.outs(w, `" type="`)
 }
 
 func (r *Renderer) imageExit(w io.Writer, image *ast.Image) {

--- a/testdata/image-2.md
+++ b/testdata/image-2.md
@@ -1,0 +1,7 @@
+Just take a look at
+
+!---
+![alt](context.svg "context")
+!---
+
+this image

--- a/testdata/image-2.xml
+++ b/testdata/image-2.xml
@@ -1,0 +1,4 @@
+<t>Just take a look at</t>
+<figure><artwork src="context.svg" type="alt" name="context"/></figure>
+<t>this image</t>
+

--- a/testdata/image.md
+++ b/testdata/image.md
@@ -1,0 +1,1 @@
+![alt](context.svg "context")

--- a/testdata/image.xml
+++ b/testdata/image.xml
@@ -1,0 +1,2 @@
+<t><artwork src="context.svg" type="alt" name="context"/></t>
+


### PR DESCRIPTION
Any alt text is used for the type attribute in rfc 7991 output.

Fixes #21