### PR TITLE
WIP: GopherJS integration

### DIFF
--- a/js/default.md
+++ b/js/default.md
@@ -1,0 +1,36 @@
+%%%
+title = "Example Protocol Specification"
+abbrev = "EPS"
+obsoletes = []
+ipr= "trust200902"
+area = "Internet"
+workgroup = "Example Working Group"
+submissiontype = "IETF"
+keyword = [""]
+
+[seriesInfo]
+name = "RFC"
+value = "8341"
+stream = "IETF"
+status = "standard"
+
+[[author]]
+initials="J.Q."
+surname="Public"
+fullname="John Q. Public"
+organization = "Yoyodyne"
+  [author.address]
+  email = "jqs@yoyodyne.example.com"
+%%%
+
+.# Abstract
+
+Abstract goes here
+
+{mainmatter}
+
+# Introduction
+
+Introduction goes here, followed by more text and more sections,
+etc.
+

--- a/js/index.html
+++ b/js/index.html
@@ -1,0 +1,236 @@
+<!doctype html5>
+<html>
+
+<head>
+<title>mmark</title>
+<script src="./js.js"></script><!-- XXX-RLB awkward naming here -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.js"></script>
+<script>
+
+const DEFAULT_DOC_URL = "./default.md"; // Document to load by default
+const SAVE_TIMEOUT    = 300;            // Milliseconds to wait before updating
+
+function xform() {
+  let doc = mmark.NewDocument($("#md").val());
+
+  // TODO XML
+  // TODO TXT
+
+  let html = doc.ToHTML();
+  let htmlBlob = new Blob([html], {type: "text/html"});
+  let htmlBlobURL = URL.createObjectURL(htmlBlob);
+  $("#html").attr("src", htmlBlobURL);
+}
+
+let state = {
+  timer: null,
+  maybeXform: function() {
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      xform();
+    }, SAVE_TIMEOUT);
+  },
+};
+
+$(document).ready(async () => {
+  // Load a default document on the Markdown side
+  let docResp = await fetch(DEFAULT_DOC_URL);
+  let docText = await docResp.text();
+  $("#md").val(docText);
+
+  // And transform it to populate the output side
+  xform()
+
+  // Automatically run the transform after a keypress, throttled with a timer
+  $("#md").keyup(() => { state.maybeXform(); })
+});
+
+</script>
+<style type="text/css">
+* {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  text-align: left;
+  font-size: 12pt;
+  font-family: Menlo, Courier, monospace;
+}
+
+#container {
+  width: 77em;
+  margin: 0 auto;
+}
+
+h1 {
+  font-size: 100%;
+  text-align: center;
+  padding-top: 1ex;
+}
+
+.tabbox {
+  display: block;
+  float: left;
+  width: 38em;
+}
+
+.tabs {
+  width: 36em;
+  float: none;
+  list-style: none;
+  position: relative;
+}
+
+.tabs li {
+  float: left;
+  display: block;
+  margin-top: 1em;
+}
+
+.tabs input[type="radio"] {
+  position: absolute;
+  top: -9999px;
+  left: -9999px;
+}
+
+.tabs label {
+  display: block;
+  padding: .5ex 2ex;
+  font-weight: bold;
+  background: white;
+  cursor: pointer;
+  position: relative;
+}
+
+.tabs label:hover {
+  background: gray;
+}
+
+.tabs .tab-content {
+  z-index: 2;
+  display: none;
+  width: 100%;
+  padding: 1ex;
+  position: absolute;
+  left: 0;
+  background: black;
+}
+
+.tabs [id^="tab"]:checked + label {
+  color:white;
+  background: black;
+}
+
+.tabs [id^="tab"]:checked ~ [id^="tab-content"] {
+  display: block;
+}
+
+.tabs [id^="md-tab"]:checked + label {
+  color:white;
+  background: black;
+}
+
+.tabs [id^="md-tab"]:checked ~ [id^="md-tab-content"] {
+  display: block;
+}
+
+.docDisplay {
+  width: 74ch;
+  height: 56em;
+  font-size: 12px;
+  display: block;
+  float: left;
+  border: 1px solid black;
+}
+
+textarea.docDisplay {
+  color: black;
+  background: white;
+  font-family: Menlo, Courier, monospace;
+}
+
+pre.docDisplay {
+  color: #333;
+  background: #eee;
+  overflow: scroll;
+}
+
+iframe.docDisplay {
+  background: white;
+}
+
+/** Download buttons **/
+.download {
+  display: block;
+  float: right;
+  background: #3498DB;
+  color: white;
+  padding: .5ex;
+  margin: 0;
+  font-size: 120%;
+  cursor: pointer;
+}
+</style>
+
+<!-- Github icon font -->
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+
+</head>
+
+<body>
+<div id="container">
+  <div class="tabbox">
+    <ul class="tabs">
+      <li>
+        <input type="radio" name="md-tabs" id="md-tab" checked />
+        <label for="md-tab">MD</label>
+        <div id="md-tab-content" class="tab-content">
+          <textarea id="md" class="docDisplay"></textarea>
+          <div id="download-md" class="download">
+            <i class="fa fa-cloud-download"></i>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="tabbox">
+    <ul class="tabs">
+      <li>
+        <input type="radio" name="tabs" id="tab2" />
+        <label for="tab2">XML</label>
+        <div id="tab-content2" class="tab-content">
+          <pre class="docDisplay"><code class="xml" id="xml"></code></pre>
+          <div id="download-xml" class="download">
+            <i class="fa fa-cloud-download"></i>
+          </div>
+        </div>
+      </li>
+      <li>
+        <input type="radio" name="tabs" id="tab3" />
+        <label for="tab3">TXT</label>
+        <div id="tab-content3" class="tab-content">
+          <pre id="txt" class="docDisplay"></pre>
+          <div id="download-txt" class="download">
+            <i class="fa fa-cloud-download"></i>
+          </div>
+        </div>
+      </li>
+      <li>
+        <input type="radio" name="tabs" id="tab4" checked />
+        <label for="tab4">HTML</label>
+        <div id="tab-content4" class="tab-content">
+          <iframe id="html" class="docDisplay"></iframe>
+          <div id="download-html" class="download">
+            <i class="fa fa-cloud-download"></i>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/js/main.go
+++ b/js/main.go
@@ -13,78 +13,9 @@ import (
 
 var standardComments = [][]byte{[]byte("//"), []byte("#")}
 
-var sampleData = `
-%%%
-title = "Network Configuration Access Control Model"
-abbrev = "NACM"
-obsoletes = [6536]
-ipr= "trust200902"
-area = "Internet"
-workgroup = "Network Working Group"
-submissiontype = "IETF"
-keyword = [""]
-date = 2018-03-01T00:00:00Z
-
-[seriesInfo]
-name = "RFC"
-value = "8341"
-stream = "IETF"
-status = "standard"
-
-[[author]]
-initials="A."
-surname="Bierman"
-fullname="Andy Bierman"
-abbrev = "YumaWorks"
-organization = "YumaWorks"
-  [author.address]
-  email = "andy@yumaworks.com"
-  [author.address.postal]
-  city = "Simi Valley"
-  street = "685 Cochran St."
-  code = "CA 93065"
-  postalline= ["Suite #160"]
-  country = "United States of America"
-[[author]]
-initials="M."
-surname="Bjorklund"
-fullname="Martin Bjorklund"
-abbrev = "Tail-f Systems"
-organization = "Tail-f Systems"
-  [author.address]
-  email = "mbj@tail-f.com"
-%%%
-
-.# Abstract
-
-The standardization of network configuration interfaces for use with the Network Configuration
-Protocol (NETCONF) or the RESTCONF protocol requires a structured and secure operating environment
-that promotes human usability and multi-vendor interoperability.  There is a need for standard
-mechanisms to restrict NETCONF or RESTCONF protocol access for particular users to a preconfigured
-subset of all available NETCONF or RESTCONF protocol operations and content.  This document defines
-such an access control model.
-
-This document obsoletes RFC 6536.
-
-{mainmatter}
-
-# Introduction
-
-The Network Configuration Protocol (NETCONF) and the RESTCONF protocol do not provide any standard
-mechanisms to restrict the protocol operations and content that each user is authorized to access.
-
-There is a need for interoperable management of the controlled access to administrator-selected
-portions of the available NETCONF or RESTCONF content within a particular server.
-
-This document addresses access control mechanisms for the Operations and Content layers of NETCONF,
-as defined in [@!RFC6241]; and RESTCONF, as defined in [@!RFC8040].  It contains three main
-sections:
-`
-
 func main() {
 	js.Global.Set("mmark", map[string]interface{}{
 		"NewDocument": NewDocument,
-		"SampleData":  sampleData,
 	})
 }
 
@@ -118,11 +49,11 @@ func NewDocument(data string) *js.Object {
 	return js.MakeWrapper(doc)
 }
 
-func (doc *Document) HTMLFragment() string {
+func (doc *Document) ToHTML() string {
 	opts := html.RendererOptions{
 		Comments:       [][]byte{[]byte("//"), []byte("#")},
 		RenderNodeHook: mhtml.RenderHook,
-		Flags:          html.CommonFlags | html.FootnoteNoHRTag | html.FootnoteReturnLinks,
+		Flags:          html.CommonFlags | html.FootnoteNoHRTag | html.FootnoteReturnLinks | html.CompletePage,
 		Title:          doc.title,
 	}
 

--- a/js/main.go
+++ b/js/main.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"github.com/gomarkdown/markdown"
+	"github.com/gomarkdown/markdown/ast"
+	"github.com/gomarkdown/markdown/html"
+	"github.com/gomarkdown/markdown/parser"
+	"github.com/gopherjs/gopherjs/js"
+	"github.com/mmarkdown/mmark/mast"
+	"github.com/mmarkdown/mmark/mparser"
+	"github.com/mmarkdown/mmark/render/mhtml"
+)
+
+var standardComments = [][]byte{[]byte("//"), []byte("#")}
+
+var sampleData = `
+%%%
+title = "Network Configuration Access Control Model"
+abbrev = "NACM"
+obsoletes = [6536]
+ipr= "trust200902"
+area = "Internet"
+workgroup = "Network Working Group"
+submissiontype = "IETF"
+keyword = [""]
+date = 2018-03-01T00:00:00Z
+
+[seriesInfo]
+name = "RFC"
+value = "8341"
+stream = "IETF"
+status = "standard"
+
+[[author]]
+initials="A."
+surname="Bierman"
+fullname="Andy Bierman"
+abbrev = "YumaWorks"
+organization = "YumaWorks"
+  [author.address]
+  email = "andy@yumaworks.com"
+  [author.address.postal]
+  city = "Simi Valley"
+  street = "685 Cochran St."
+  code = "CA 93065"
+  postalline= ["Suite #160"]
+  country = "United States of America"
+[[author]]
+initials="M."
+surname="Bjorklund"
+fullname="Martin Bjorklund"
+abbrev = "Tail-f Systems"
+organization = "Tail-f Systems"
+  [author.address]
+  email = "mbj@tail-f.com"
+%%%
+
+.# Abstract
+
+The standardization of network configuration interfaces for use with the Network Configuration
+Protocol (NETCONF) or the RESTCONF protocol requires a structured and secure operating environment
+that promotes human usability and multi-vendor interoperability.  There is a need for standard
+mechanisms to restrict NETCONF or RESTCONF protocol access for particular users to a preconfigured
+subset of all available NETCONF or RESTCONF protocol operations and content.  This document defines
+such an access control model.
+
+This document obsoletes RFC 6536.
+
+{mainmatter}
+
+# Introduction
+
+The Network Configuration Protocol (NETCONF) and the RESTCONF protocol do not provide any standard
+mechanisms to restrict the protocol operations and content that each user is authorized to access.
+
+There is a need for interoperable management of the controlled access to administrator-selected
+portions of the available NETCONF or RESTCONF content within a particular server.
+
+This document addresses access control mechanisms for the Operations and Content layers of NETCONF,
+as defined in [@!RFC6241]; and RESTCONF, as defined in [@!RFC8040].  It contains three main
+sections:
+`
+
+func main() {
+	js.Global.Set("mmark", map[string]interface{}{
+		"NewDocument": NewDocument,
+		"SampleData":  sampleData,
+	})
+}
+
+type Document struct {
+	title string
+	root  ast.Node
+}
+
+func NewDocument(data string) *js.Object {
+	init := mparser.NewInitial("")
+
+	doc := &Document{}
+
+	p := parser.NewWithExtensions(mparser.Extensions)
+	parserFlags := parser.FlagsNone
+	p.Opts = parser.Options{
+		ParserHook: func(data []byte) (ast.Node, []byte, int) {
+			node, data, consumed := mparser.Hook(data)
+			if t, ok := node.(*mast.Title); ok {
+				if !t.IsTriggerDash() {
+					doc.title = t.TitleData.Title
+				}
+			}
+			return node, data, consumed
+		},
+		ReadIncludeFn: init.ReadInclude,
+		Flags:         parserFlags,
+	}
+
+	doc.root = markdown.Parse([]byte(data), p)
+	return js.MakeWrapper(doc)
+}
+
+func (doc *Document) HTMLFragment() string {
+	opts := html.RendererOptions{
+		Comments:       [][]byte{[]byte("//"), []byte("#")},
+		RenderNodeHook: mhtml.RenderHook,
+		Flags:          html.CommonFlags | html.FootnoteNoHRTag | html.FootnoteReturnLinks,
+		Title:          doc.title,
+	}
+
+	renderer := html.NewRenderer(opts)
+	x := markdown.Render(doc.root, renderer)
+	return string(x)
+}


### PR DESCRIPTION
My earlier work on [draftr](https://ipv.sx/draftr) and [draftr-js](https://draftr-js.github.io) was pretty half-hearted, but the "no install" experience has been useful to a few people.  It would be nice, though, if we could have a web-based Internet-draft authoring tool that kept pace with the more real tooling -- mmark.

This PR is a proof of concept for how this could be done fairly simply using GopherJS.  To see how this works:

```
> go get -u github.com/gopherjs/gopherjs
> cd ${GOPATH}/src/github.com/mmarkdown/mmark/js
> gopherjs serve

# In browser opened to http://localhost:8080/github.com/mmarkdown/mmark/js
# Open browser console, and:
> doc = mmark.NewDocument(mmark.SampleData)
> html = doc.HTMLFragment()
```