### PR TITLE
Use submissionType

### DIFF
--- a/mast/title.go
+++ b/mast/title.go
@@ -40,7 +40,7 @@ type TitleData struct {
 	Ipr            string // See https://tools.ietf.org/html/rfc7991#appendix-A.1
 	Obsoletes      []int
 	Updates        []int
-	SubmissionType string // IETF, IAB, IRTF or independent
+	SubmissionType string // IETF, IAB, IRTF or independent, defaults to IETF.
 
 	Date      time.Time
 	Area      string
@@ -54,7 +54,7 @@ type SeriesInfo struct {
 	Name   string // name of the document, values are "RFC", "Internet-Draft", and "DOI"
 	Value  string // either draft name, or number
 	Status string // The status of this document, values: "standard", "informational", "experimental", "bcp", "fyi", and "full-standard"
-	Stream string // "IETF" (default),"IAB", "IRTF" or "independent"
+	Stream string // "IETF" (default), "IAB", "IRTF" or "independent"
 }
 
 // Author denotes an RFC author.

--- a/render/xml/title.go
+++ b/render/xml/title.go
@@ -37,16 +37,27 @@ func (r *Renderer) titleBlock(w io.Writer, t *mast.Title) {
 	if d == nil {
 		return
 	}
+	if d.SubmissionType == "" {
+		d.SubmissionType = "IETF"
+	}
 
 	// rfc tag
 	attrs := Attributes(
-		[]string{"version", "ipr", "docName", "submissionType", "category", "xml:lang", "consensus", "xmlns:xi"},
-		[]string{"3", d.Ipr, t.SeriesInfo.Value, "IETF", StatusToCategory[d.SeriesInfo.Status], "en", fmt.Sprintf("%t", d.Consensus), "http://www.w3.org/2001/XInclude"},
+		[]string{"version", "ipr", "docName", "submissionType", "category", "xml:lang", "xmlns:xi"},
+		[]string{"3", d.Ipr, t.SeriesInfo.Value, d.SubmissionType, StatusToCategory[d.SeriesInfo.Status], "en", "http://www.w3.org/2001/XInclude"},
 	)
 	attrs = append(attrs, Attributes(
 		[]string{"updates", "obsoletes"},
 		[]string{IntSliceToString(d.Updates), IntSliceToString(d.Obsoletes)},
 	)...)
+	// Only for IETF stream add the consensus attribute.
+	if d.SubmissionType == "IETF" {
+		attrs = append(attrs, Attributes(
+			[]string{"Consensus"},
+			[]string{fmt.Sprintf("%t", d.Consensus)},
+		)...)
+	}
+
 	// number is deprecated, but xml2rfc want's it here to generate an actual RFC.
 	// But only if number is a integer...
 	if _, err := strconv.Atoi(t.SeriesInfo.Value); err == nil {


### PR DESCRIPTION
If empty use IETF as the default. Also only for IETF documents add the
consensus attribute.

Signed-off-by: Miek Gieben <miek@miek.nl>