### PR TITLE
Case-insensitive lang lookup for BCP 47 conformance

### DIFF
--- a/lang/lang.go
+++ b/lang/lang.go
@@ -1,10 +1,15 @@
 package lang
 
+import (
+	"strings"
+)
+
 // New returns a new and initialized Lang.
 func New(language string) Lang {
-	l := Lang{language: language}
+	l := Lang{language: strings.ToLower(language)} // case insensitivity
 
 	// Add all lanaguages here, the keys should be named according to BCP47.
+	// The keys must be in all lower case for normalized lookup.
 	l.m = map[string]Term{
 		"en": Term{
 			Footnotes:    "Footnotes",


### PR DESCRIPTION
Language tags are described to be case-insensitive in BCP 47.

> __2.1.1.  Formatting of Language Tags__
>
> At all times, language tags and their subtags, including private use
   and extensions, are to be treated as case insensitive: there exist
   conventions for the capitalization of some of the subtags, but these
   MUST NOT be taken to carry meaning.
>
> Thus, the tag "mn-Cyrl-MN" is not distinct from "MN-cYRL-mn" or "mN-
   cYrL-Mn" (or any other combination), and each of these variations
   conveys the same meaning: Mongolian written in the Cyrillic script as
   used in Mongolia.

So we have to normalize the casing in order to be conformant to BCP 47. One of the easiest ways is to convert the input to the lower case, I believe.