### PR TITLE
man: convert tabs to spaces for codeblocks

### DIFF
--- a/Syntax.md
+++ b/Syntax.md
@@ -256,6 +256,9 @@ Images:
 References and citations:
 :   Supported, a "Bibliography" section is added.
 
+Code Block:
+:   Tabs are converted into spaces.
+
 
 ## Block Elements
 

--- a/Syntax.md
+++ b/Syntax.md
@@ -257,7 +257,7 @@ References and citations:
 :   Supported, a "Bibliography" section is added.
 
 Code Block:
-:   Tabs are converted into spaces.
+:   Tabs are converted into four spaces.
 
 
 ## Block Elements

--- a/render/man/helpers.go
+++ b/render/man/helpers.go
@@ -40,6 +40,9 @@ func escapeSpecialChars(r *Renderer, w io.Writer, text []byte) {
 			r.out(w, []byte{text[i]})
 			continue
 		}
+		if text[i] == '\t' {
+			r.outs(w, " ")
+		}
 
 		if needsBackslash(text[i]) {
 			r.out(w, []byte{'\\'})

--- a/render/man/helpers.go
+++ b/render/man/helpers.go
@@ -41,7 +41,8 @@ func escapeSpecialChars(r *Renderer, w io.Writer, text []byte) {
 			continue
 		}
 		if text[i] == '\t' {
-			r.outs(w, " ")
+			r.outs(w, "    ")
+			continue
 		}
 
 		if needsBackslash(text[i]) {

--- a/testdata/man/codeblock-tab.fmt
+++ b/testdata/man/codeblock-tab.fmt
@@ -1,0 +1,14 @@
+
+.PP
+.RS
+
+.nf
+cluster.local:53 {
+    kubernetes cluster.local {
+    upstream
+    }
+}
+
+.fi
+.RE
+

--- a/testdata/man/codeblock-tab.md
+++ b/testdata/man/codeblock-tab.md
@@ -1,0 +1,7 @@
+~~~ txt
+cluster.local:53 {
+	kubernetes cluster.local {
+	upstream
+    }
+}
+~~~


### PR DESCRIPTION
Leaving the tabs in place made the code go all over the place. Just
convert them to spaces.