### PR TITLE
markdown: fix Table caption

### DIFF
--- a/render/markdown/renderer.go
+++ b/render/markdown/renderer.go
@@ -302,7 +302,10 @@ func (r *Renderer) table(w io.Writer, tab *ast.Table, entering bool) {
 	} else {
 		r.colWidth = []int{}
 		r.colAlign = []ast.CellAlignFlags{}
-		r.newline(w)
+		if _, inCaption := tab.Parent.(*ast.CaptionFigure); !inCaption {
+			// The caption must be attached to the table.
+			r.newline(w)
+		}
 	}
 }
 

--- a/testdata/markdown/table-caption.fmt
+++ b/testdata/markdown/table-caption.fmt
@@ -1,0 +1,10 @@
+Name     | Age
+---------|-----
+Bob      | 27
+Alice    | 23
+Charlie  | 1
+=========|=====
+Total    | 50
+Table: Showing ages of various people.
+
+More text.

--- a/testdata/markdown/table-caption.md
+++ b/testdata/markdown/table-caption.md
@@ -1,0 +1,10 @@
+Name | Age
+---|---
+Bob | 27
+Alice | 23
+Charlie | 1
+=====|==
+Total | 50
+Table: Showing ages of various people.
+
+More text.


### PR DESCRIPTION
When a caption is present it needs to be next to the table, without a
newline. Fix this and add a test for it.