### PR TITLE
mmark: tighten lists

### DIFF
--- a/render/xml/renderer.go
+++ b/render/xml/renderer.go
@@ -224,6 +224,10 @@ func (r *Renderer) paragraphEnter(w io.Writer, para *ast.Paragraph) {
 		if p.ListFlags&ast.ListTypeTerm != 0 {
 			return
 		}
+		if p.ListFlags&ast.ListItemContainsBlock == 0 {
+			// no block level elements, don't output a paragraph
+			return
+		}
 	}
 	if _, ok := para.Parent.(*ast.CaptionFigure); ok {
 		return
@@ -235,6 +239,10 @@ func (r *Renderer) paragraphEnter(w io.Writer, para *ast.Paragraph) {
 func (r *Renderer) paragraphExit(w io.Writer, para *ast.Paragraph) {
 	if p, ok := para.Parent.(*ast.ListItem); ok {
 		if p.ListFlags&ast.ListTypeTerm != 0 {
+			return
+		}
+		if p.ListFlags&ast.ListItemContainsBlock == 0 {
+			// no block level elements, don't output a paragraph
 			return
 		}
 	}

--- a/rfc/5841.md
+++ b/rfc/5841.md
@@ -165,7 +165,7 @@ expressed, but it is up to the developers to determine when to apply these encod
 
 ## Happy Packets
 
-Healthy packets are happy packets you could say.  If the ACK packets return within <10 ms end-to-end
+Healthy packets are happy packets you could say. If the ACK packets return within \<10 ms end-to-end
 from a sender's stack to a receiver's stack and back again, this would reflect high-speed
 bidirectional capability, and if no retransmits are required and all ACKs are received, all
 subsequent packets in that session **SHOULD** be marked as 'happy'.

--- a/testdata/list.md
+++ b/testdata/list.md
@@ -1,0 +1,5 @@
+ *  item2
+
+ *  item3
+
+    another paragraph

--- a/testdata/list.xml
+++ b/testdata/list.xml
@@ -1,0 +1,7 @@
+<ul>
+<li><t>item2</t>
+</li>
+<li><t>item3</t>
+<t>another paragraph</t>
+</li>
+</ul>

--- a/testdata/liststart.xml
+++ b/testdata/liststart.xml
@@ -1,6 +1,4 @@
 <ol start="2">
-<li><t>item2</t>
-</li>
-<li><t>item3</t>
-</li>
+<li>item2</li>
+<li>item3</li>
 </ol>


### PR DESCRIPTION
If a list does not contain any blocklevel elements suppress the output
of <t>'s. See https://tools.ietf.org/html/rfc7991#section-2.29 where
this is specified. The makes the outputted lists in the much tighter in
the generated xml/text/html.

Fixes: #105