### PR TITLE
Revert "mmark: tighten lists (#106)"

### DIFF
--- a/render/xml/renderer.go
+++ b/render/xml/renderer.go
@@ -224,10 +224,6 @@ func (r *Renderer) paragraphEnter(w io.Writer, para *ast.Paragraph) {
 		if p.ListFlags&ast.ListTypeTerm != 0 {
 			return
 		}
-		if p.ListFlags&ast.ListItemContainsBlock == 0 {
-			// no block level elements, don't output a paragraph
-			return
-		}
 	}
 	if _, ok := para.Parent.(*ast.CaptionFigure); ok {
 		return
@@ -239,10 +235,6 @@ func (r *Renderer) paragraphEnter(w io.Writer, para *ast.Paragraph) {
 func (r *Renderer) paragraphExit(w io.Writer, para *ast.Paragraph) {
 	if p, ok := para.Parent.(*ast.ListItem); ok {
 		if p.ListFlags&ast.ListTypeTerm != 0 {
-			return
-		}
-		if p.ListFlags&ast.ListItemContainsBlock == 0 {
-			// no block level elements, don't output a paragraph
 			return
 		}
 	}

--- a/rfc/5841.md
+++ b/rfc/5841.md
@@ -165,7 +165,7 @@ expressed, but it is up to the developers to determine when to apply these encod
 
 ## Happy Packets
 
-Healthy packets are happy packets you could say. If the ACK packets return within \<10 ms end-to-end
+Healthy packets are happy packets you could say.  If the ACK packets return within <10 ms end-to-end
 from a sender's stack to a receiver's stack and back again, this would reflect high-speed
 bidirectional capability, and if no retransmits are required and all ACKs are received, all
 subsequent packets in that session **SHOULD** be marked as 'happy'.

--- a/testdata/list.md
+++ b/testdata/list.md
@@ -1,5 +1,0 @@
- *  item2
-
- *  item3
-
-    another paragraph

--- a/testdata/list.xml
+++ b/testdata/list.xml
@@ -1,7 +1,0 @@
-<ul>
-<li><t>item2</t>
-</li>
-<li><t>item3</t>
-<t>another paragraph</t>
-</li>
-</ul>

--- a/testdata/liststart.xml
+++ b/testdata/liststart.xml
@@ -1,4 +1,6 @@
 <ol start="2">
-<li>item2</li>
-<li>item3</li>
+<li><t>item2</t>
+</li>
+<li><t>item3</t>
+</li>
 </ol>


### PR DESCRIPTION
Breaks XML generates, see #107

This reverts commit dfdc775543739c2a874b08cc7c18b40eb34156a7.

Fixes: #107