### PR TITLE
Remove -2 option from manpage

### DIFF
--- a/mmark.1
+++ b/mmark.1
@@ -99,9 +99,6 @@ link to HTML to be included in head (only used with -html).
 \fB-html\fP
 create HTML output.
 .TP
-\fB-2\fP
-generate RFC 7749 XML.
-.TP
 \fB-markdown\fP
 output (normalized) markdown.
 .TP


### PR DESCRIPTION
This was removed as part of mmarkdown#97 but survived the deletion in the manpage file.