### PR TITLE
Add artset support

### DIFF
--- a/Syntax-images.md
+++ b/Syntax-images.md
@@ -1,0 +1,51 @@
+---
+title: "Images in Mmark"
+date: 2020-10-12T10:05:51+01:00
+aliases: [/syntax/images]
+toc: true
+---
+
+Images in Mmark are somewhat complicated, not in the least, because XML2RFC needs to output both
+HTML and text. To make that work you can specify multiple images in an `artset` and the renderer will
+pick the correct one, depending on the output.
+
+To include artwork/source/images, you can:
+
+* Use a code block. If this has a language specified, it will become a `sourcecode` otherwise a will
+  be an `artwork`. The contents of both must be in plain text.
+* Use subfigures in a figure block (`!--`) to group figure and potentially make them have a caption.
+  We also use this syntax to support an `artset`, but only under special conditions (see below).
+
+## Code Blocks
+
+A code block *with* a language will be turned into a `sourcecode`:
+
+    ``` go
+    println("hello!")
+    ```
+
+If no language is given it will be an `artwork`.
+
+## Subfigures
+
+To support `artset` we do the following. If multiple images are present as subfigures, we check
+if the name *without* the extension of the image destination (the file to be shown) is equal for all
+subfigures. If so, we assume an `artset` needs to be outputted and do so.
+
+For example the following will result in a artset where an `svg` and an `ascii-art` version of the
+(hopefully) same image exists. Note the extension **must** be `ascii-art` because we use that to set
+the type and XML2RFC checks for that string.
+
+~~~
+!---
+![Array vs Slice](array-vs-slice.svg "Title of the image")
+![Array vs Slice](array-vs-slice.ascii-art "Title of the image")
+!---
+~~~
+
+Note this syntax is also supported for the manual page output and it does the same thing by only
+using the `ascii-art` version. This is true for all included imagary; only `ascii-art` ones are
+included in the output.
+
+By some happy co-indicence a browser will not show the `ascii-art` version of the image. It remains
+to be seen if we need some code to actually filter these out.

--- a/Syntax.md
+++ b/Syntax.md
@@ -90,7 +90,8 @@ Mmark adds:
 * [Captions](#captions) for code, tables, quotes and subfigures.
 * [Asides](#asides).
 * [Figures and Subfigures](#figures-and-subfigures) - allows grouping images into subfigures as
-  well as giving a single image metadata (a link, attributes, etc.).
+  well as giving a single image metadata (a link, attributes, etc.). See [Images in
+  Mmark](/syntax/images) for more details.
 * [Block Level Attributes](#block-level-attributes) that allow to specify attributes, classes and
   IDs for elements.
 * [Indices](#indices) to mark an item (and/or a subitem) to be referenced in the document index.
@@ -172,11 +173,12 @@ Footnotes:
 
 Images:
 :   Images are supported, but only SVG graphics are allowed. We convert this to
-    an `<artwork>` with `src` set to the image URL of path. I.e. `![svg](img.svg "title")` becomes
+    an `<artwork>` with `src` set to the image URL of path. I.e. `![alt text](img.svg "title")` becomes
     `<artwork src="img.svg" type="svg" name="title"/>`. Note the first `svg` (the alt text) is used
     as the `type=` attribute. Also note that an image like this will be wrapped in `<t>` which is
     not allowed in RFC 7991 syntax. So to make this fully work you need to the image in a subfigure:
     `!---`.
+    See [Images in Mmark](/syntax/images) for more details.
 
 Horizontal Line:
 :   Outputs a paragraph with 60 dashes `-`.
@@ -184,8 +186,6 @@ Horizontal Line:
 Comments:
 :   HTML Comments are detected and discarded. These can be useful to make the parser parse certain
     constructs as a block element without meddling with the output.
-
-
 
 HTML:
 :   The `<br>` tag is detected and converted into a hard break.
@@ -211,7 +211,8 @@ Title Block:
     * `date`, date of the man page, optional, defaults to "today".
 
 Images:
-:   Not supported.
+:   See [Images in Mmark](/syntax/images) for details, `ascii-art` images from a sub-figure are
+    included.
 
 References and citations:
 :   Supported, a "Bibliography" section is added.
@@ -417,7 +418,7 @@ quote, but can be styled differently.
 To *group* artworks and code blocks into figures, we need an extra syntax element. [Scholarly
 markdown] has a neat syntax for this. It uses a special section syntax and all images in that
 section become subfigures of a larger figure. Disadvantage of this syntax is that it can not be used
-in lists. Hence we use a fenced code block like syntax: `!---` as the opening and closing "tag".
+in lists. We use a fenced code block like syntax: `!---` as the opening and closing "tag".
 Note: only inline elements are parsed inside a figure block.
 
 Basic usage:

--- a/testdata/artset.md
+++ b/testdata/artset.md
@@ -1,0 +1,4 @@
+!---
+![svg](array-vs-slice.svg "Image1")
+![ascii-art](array-vs-slice.ascii-art "Image2")
+!---

--- a/testdata/artset.xml
+++ b/testdata/artset.xml
@@ -1,0 +1,4 @@
+<figure><artset>
+<artwork src="array-vs-slice.svg" type="svg" alt="svg" name="Image1"/>
+<artwork src="array-vs-slice.ascii-art" type="ascii-art" alt="ascii-art" name="Image2"/></artset>
+</figure>


### PR DESCRIPTION
Add support for artset to we let xm2rfc pick the correct format when
generating output. This also fixes image output for manpage where we do
the same thing as xml2rfc, only use the ascii-art one for text output.

Signed-off-by: Miek Gieben <miek@miek.nl>