### PR TITLE
reference: support referencegroup

### DIFF
--- a/Syntax.md
+++ b/Syntax.md
@@ -566,6 +566,9 @@ Note that for citing I-Ds and RFCs you *don't* need to include any XML, as Mmark
 automatically from their online location: or technically more correct: the xml2rfc post processor
 will do this.
 
+The newer `referencegroup` is also supported. No attempt to parse it is made, it's detected and
+included in the bibliography.
+
 ### Cross References
 
 Cross references can use the syntax `[](#id)`, but usually the need for the title within the

--- a/mast/bibliography.go
+++ b/mast/bibliography.go
@@ -20,5 +20,6 @@ type BibliographyItem struct {
 	Anchor []byte
 	Type   ast.CitationTypes
 
-	Reference *reference.Reference // parsed reference XML
+	Reference      *reference.Reference // parsed reference XML
+	ReferenceGroup []byte               // raw, unparsed reference group  XML
 }

--- a/render/xml/bibliography.go
+++ b/render/xml/bibliography.go
@@ -39,6 +39,13 @@ func (r *Renderer) bibliographyItem(w io.Writer, node *mast.BibliographyItem) {
 		return
 	}
 
+	if node.ReferenceGroup != nil {
+		// output this raw
+		r.out(w, node.ReferenceGroup)
+		r.cr(w)
+		return
+	}
+
 	tag := ""
 	switch {
 	case bytes.HasPrefix(node.Anchor, []byte("RFC")):


### PR DESCRIPTION
This add supports for referencegroups.

See https://www.rfc-editor.org/materials/FAQ-xml2rfcv3.html#section-3.8

Signed-off-by: Miek Gieben <miek@miek.nl>
