### PR TITLE
contacts: make para only containing contacts special

### DIFF
--- a/Syntax.md
+++ b/Syntax.md
@@ -330,6 +330,17 @@ You can then *reference* this contact using a *citation* via the `fullname`: `[@
 This also works when referencing an author of the I-D. Note just like authors, defining contacts
 needs to happen in the titleblock.
 
+To renders contacts just like the authors are rendered, they need to be a put directly after opening
+a new section in the *first* paragraph:
+
+~~~
+# Acknowledgements
+
+[@R. (Miek) Gieben] [@More Folk]
+
+Miek wrote ..., While More wrote ..
+~~~
+
 ### Special Sections
 
 Any section that needs special handling, like an abstract or preface can be started with `.#


### PR DESCRIPTION
In xml2rfc is a <contact> is inserted right after a <section> it is
rendered like an author. To mimic this if you only reference contact in
a paragraph, that is the first paragraph after a heading we will output
the correct XML.

Signed-off-by: Miek Gieben <miek@miek.nl>
