### PR TITLE
Allow FYI documents

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,12 +4,4 @@
 
 ## What version of mmark are you using?
 
-## What command line did you use?
-
-## What platform (Linux/Apple/Windows)?
-
-- [ ] Linux
-- [ ] Apple
-- [ ] Windows
-
 ## What is the *most* minimal markdown snippets that shows the problem?

--- a/FAQ.md
+++ b/FAQ.md
@@ -38,6 +38,20 @@ do for normal Internet-Draft documents.
 Set `submissiontype` and `stream` in `seriesInfo` to *IAB*. Items like `workgroup` are (I believe)
 ignored for this stream.
 
+# How Do I Create an FYI Document?
+
+Use this as the `seriesInfo`:
+
+~~~ toml
+[seriesInfo]
+name = "FYI"
+value = "2100"
+stream = "IETF"
+status = "informational"
+~~~
+
+Note this makes xml2rfc still complain, but at least creates valid XML.
+
 # How Do I Make an Author an Editor
 
 Use `role = "editor"` in the author's section in the titleblock.

--- a/Syntax.md
+++ b/Syntax.md
@@ -261,7 +261,7 @@ An I-D needs to have a Title Block with the following items filled out:
 * `title` - the main title of the document.
 * `abbrev` - abbreviation of the title.
 * `updates/obsoletes` - array of integers.
-* `seriesInfo`, containing (the implementation in xml2rfc does not RFC 7991 anymore)
+* `seriesInfo`, containing:
    * `name` - `RFC`, `Internet-Draft`, `DOI`, or `FYI`.
    * `value` - draft name or RFC number
    * `stream` - `IETF` (default), `IAB`, `IRTF` or `independent`.

--- a/Syntax.md
+++ b/Syntax.md
@@ -261,11 +261,11 @@ An I-D needs to have a Title Block with the following items filled out:
 * `title` - the main title of the document.
 * `abbrev` - abbreviation of the title.
 * `updates/obsoletes` - array of integers.
-* `seriesInfo`, containing (this might change with the new *new* XMLv3 output)
-   * `name` - `RFC` or `Internet-Draft` or `DOI`
+* `seriesInfo`, containing (the implementation in xml2rfc does not RFC 7991 anymore)
+   * `name` - `RFC`, `Internet-Draft`, `DOI`, or `FYI`.
    * `value` - draft name or RFC number
    * `stream` - `IETF` (default), `IAB`, `IRTF` or `independent`.
-   * `status` - `standard`, `informational`, `experimental`, `bcp`, `fyi`, or `full-standard`.
+   * `status` - `standard`, `informational`, `experimental`, `bcp`, `historic`, or `full-standard`.
 * `ipr` - usually just set `trust200902`.
 * `area` - usually just `Internet`.
 * `workgroup` - the workgroup the document is created for.

--- a/render/xml/title.go
+++ b/render/xml/title.go
@@ -14,17 +14,14 @@ import (
 	"github.com/mmarkdown/mmark/mast/reference"
 )
 
-// TODO(miek): double check if this is how it works.
-
 // StatusToCategory translate the status to a category.
 var StatusToCategory = map[string]string{
+	"full-standard": "std",
 	"standard":      "std",
 	"informational": "info",
 	"experimental":  "exp",
 	"bcp":           "bcp",
-	"fyi":           "fyi",
-	"full-standard": "std",
-	// historic??
+	"historic":      "historic",
 }
 
 func (r *Renderer) titleBlock(w io.Writer, t *mast.Title) {


### PR DESCRIPTION
Document how this works and have some tiny fixes in the code, fyi is a
`name` in `seriesInfo` not a `status`

Fixes: #134

Signed-off-by: Miek Gieben <miek@miek.nl>
