### PR TITLE
reference: omit date element when not set

### DIFF
--- a/mast/reference/reference.go
+++ b/mast/reference/reference.go
@@ -52,7 +52,7 @@ type Date struct {
 type Front struct {
 	Title   string   `xml:"title"`
 	Authors []Author `xml:"author,omitempty"`
-	Date    Date     `xml:"date"`
+	Date    *Date    `xml:"date,omitempty"`
 }
 
 // Format is the reference <format>. This is deprecated in RFC 7991, see Section 3.3.

--- a/mast/reference/reference_test.go
+++ b/mast/reference/reference_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestReferenceOrganization(t *testing.T) {
+func TestReference(t *testing.T) {
 	in := []byte(`<reference anchor='IANA' target='https://www.iana.org/assignments/media-types/media-types.xhtml'>
     <front>
         <title abbrev='IANA'>IANA Media Types</title>
@@ -17,6 +17,33 @@ func TestReferenceOrganization(t *testing.T) {
 </reference>
 `)
 	expect := `<reference anchor="IANA" target="https://www.iana.org/assignments/media-types/media-types.xhtml"><front><title>IANA Media Types</title><author><organization>IANA</organization></author><date year="2019" month="February"></date></front></reference>`
+
+	var x Reference
+	if err := xml.Unmarshal(in, &x); err != nil {
+		t.Errorf("failed to unmarshal reference: %s: %s", in, err)
+	}
+	out, err := xml.Marshal(x)
+	if err != nil {
+		t.Errorf("failed to marshal reference: %s", err)
+	}
+	str := string(out)
+
+	if str != expect {
+		t.Errorf("expected\n%s\ngot\n%s", expect, str)
+	}
+}
+
+func TestReferenceDate(t *testing.T) {
+	in := []byte(`<reference anchor='IANA' target='https://www.iana.org/assignments/media-types/media-types.xhtml'>
+    <front>
+        <title abbrev='IANA'>IANA Media Types</title>
+        <author>
+            <organization>IANA</organization>
+        </author>
+    </front>
+</reference>
+`)
+	expect := `<reference anchor="IANA" target="https://www.iana.org/assignments/media-types/media-types.xhtml"><front><title>IANA Media Types</title><author><organization>IANA</organization></author></front></reference>`
 
 	var x Reference
 	if err := xml.Unmarshal(in, &x); err != nil {


### PR DESCRIPTION
Remove <date></date> from the generated xml.

Fixes: #138

Signed-off-by: Miek Gieben <miek@miek.nl>
