### PR TITLE
Fix reference test

### DIFF
--- a/mast/reference/reference.go
+++ b/mast/reference/reference.go
@@ -79,5 +79,5 @@ type Reference struct {
 	Format     *Format     `xml:"format,omitempty"`
 	Target     string      `xml:"target,attr"`
 	Series     *SeriesInfo `xml:"seriesInfo,omitempty"`
-	RefContent string      `xml:"refcontent"`
+	RefContent string      `xml:"refcontent,omitempty"`
 }


### PR DESCRIPTION
Add omitempty to refcontant to make test not fail.

Signed-off-by: Miek Gieben <miek@miek.nl>
