### PR TITLE
Fix a bug where an empty postal entity is added to the address

### DIFF
--- a/mast/reference/reference.go
+++ b/mast/reference/reference.go
@@ -27,7 +27,7 @@ type Address struct {
 	Phone  string        `xml:"phone,omitempty"`
 	Email  string        `xml:"email,omitempty"`
 	URI    string        `xml:"uri,omitempty"`
-	Postal AddressPostal `xml:"postal,omitempty"`
+	Postal *AddressPostal `xml:"postal,omitempty"`
 }
 
 // AddressPostal denotes the postal address of an RFC author.


### PR DESCRIPTION
Fixes #149 where an empty `postal` entity is added to the `address`.