### PR TITLE
Honor tight lists

### DIFF
--- a/render/xml/renderer.go
+++ b/render/xml/renderer.go
@@ -388,6 +388,9 @@ func (r *Renderer) listEnter(w io.Writer, nodeData *ast.List) {
 	if nodeData.ListFlags&ast.ListTypeDefinition != 0 {
 		openTag = "<dl"
 	}
+	if nodeData.Tight {
+		mast.SetAttribute(nodeData, "spacing", []byte("compact"))
+	}
 	r.outTag(w, openTag, html.BlockAttrs(nodeData))
 	r.cr(w)
 }

--- a/testdata/liststart.xml
+++ b/testdata/liststart.xml
@@ -1,4 +1,4 @@
-<ol start="2">
+<ol spacing="compact" start="2">
 <li>item2</li>
 <li>item3</li>
 </ol>

--- a/testdata/listtight.xml
+++ b/testdata/listtight.xml
@@ -1,8 +1,8 @@
-<ol>
+<ol spacing="compact">
 <li>a</li>
 <li><t>b</t>
 
-<ol>
+<ol spacing="compact">
 <li>c</li>
 <li>d</li>
 </ol></li>


### PR DESCRIPTION
When a list is tight, output the spacing=compact attribute in the XML
for XML2RFC.

Signed-off-by: Miek Gieben <miek@miek.nl>
