### PR TITLE
Rename import paths to respect go's SIV

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mmarkdown/mmark
+module github.com/mmarkdown/mmark/v2
 
 go 1.13
 

--- a/mast/bibliography.go
+++ b/mast/bibliography.go
@@ -1,7 +1,7 @@
 package mast
 
 import (
-	"github.com/mmarkdown/mmark/mast/reference"
+	"github.com/mmarkdown/mmark/v2/mast/reference"
 
 	"github.com/gomarkdown/markdown/ast"
 )

--- a/mast/title.go
+++ b/mast/title.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/gomarkdown/markdown/ast"
-	"github.com/mmarkdown/mmark/mast/reference"
+	"github.com/mmarkdown/mmark/v2/mast/reference"
 )
 
 // Title represents the TOML encoded title block.

--- a/mmark.go
+++ b/mmark.go
@@ -7,12 +7,12 @@ import (
 	"log"
 	"os"
 
-	"github.com/mmarkdown/mmark/lang"
-	"github.com/mmarkdown/mmark/mast"
-	"github.com/mmarkdown/mmark/mparser"
-	"github.com/mmarkdown/mmark/render/man"
-	"github.com/mmarkdown/mmark/render/mhtml"
-	"github.com/mmarkdown/mmark/render/xml"
+	"github.com/mmarkdown/mmark/v2/lang"
+	"github.com/mmarkdown/mmark/v2/mast"
+	"github.com/mmarkdown/mmark/v2/mparser"
+	"github.com/mmarkdown/mmark/v2/render/man"
+	"github.com/mmarkdown/mmark/v2/render/mhtml"
+	"github.com/mmarkdown/mmark/v2/render/xml"
 
 	"github.com/gomarkdown/markdown"
 	"github.com/gomarkdown/markdown/ast"

--- a/mmark_man_test.go
+++ b/mmark_man_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/mmarkdown/mmark/mparser"
-	"github.com/mmarkdown/mmark/render/man"
+	"github.com/mmarkdown/mmark/v2/mparser"
+	"github.com/mmarkdown/mmark/v2/render/man"
 
 	"github.com/gomarkdown/markdown"
 	"github.com/gomarkdown/markdown/parser"

--- a/mmark_test.go
+++ b/mmark_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/mmarkdown/mmark/mparser"
-	"github.com/mmarkdown/mmark/render/xml"
+	"github.com/mmarkdown/mmark/v2/mparser"
+	"github.com/mmarkdown/mmark/v2/render/xml"
 
 	"github.com/gomarkdown/markdown"
 	"github.com/gomarkdown/markdown/parser"

--- a/mparser/bibliography.go
+++ b/mparser/bibliography.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"sort"
 
-	"github.com/mmarkdown/mmark/mast"
-	"github.com/mmarkdown/mmark/mast/reference"
+	"github.com/mmarkdown/mmark/v2/mast"
+	"github.com/mmarkdown/mmark/v2/mast/reference"
 
 	"github.com/gomarkdown/markdown/ast"
 )

--- a/mparser/index.go
+++ b/mparser/index.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/mmarkdown/mmark/mast"
+	"github.com/mmarkdown/mmark/v2/mast"
 
 	"github.com/gomarkdown/markdown/ast"
 )

--- a/mparser/title.go
+++ b/mparser/title.go
@@ -3,7 +3,7 @@ package mparser
 import (
 	"log"
 
-	"github.com/mmarkdown/mmark/mast"
+	"github.com/mmarkdown/mmark/v2/mast"
 
 	"github.com/BurntSushi/toml"
 	"github.com/gomarkdown/markdown/ast"

--- a/render/man/authors.go
+++ b/render/man/authors.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/gomarkdown/markdown/ast"
-	"github.com/mmarkdown/mmark/mast"
+	"github.com/mmarkdown/mmark/v2/mast"
 )
 
 // authors creates a 'Authors' section that can be included. Only the 'fullname' is used.

--- a/render/man/renderer.go
+++ b/render/man/renderer.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mmarkdown/mmark/lang"
-	"github.com/mmarkdown/mmark/mast"
+	"github.com/mmarkdown/mmark/v2/lang"
+	"github.com/mmarkdown/mmark/v2/mast"
 
 	"github.com/gomarkdown/markdown/ast"
 	"github.com/gomarkdown/markdown/html"

--- a/render/mhtml/hook.go
+++ b/render/mhtml/hook.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/mmarkdown/mmark/lang"
-	"github.com/mmarkdown/mmark/mast"
+	"github.com/mmarkdown/mmark/v2/lang"
+	"github.com/mmarkdown/mmark/v2/mast"
 
 	"github.com/gomarkdown/markdown/ast"
 )

--- a/render/xml/bibliography.go
+++ b/render/xml/bibliography.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/mmarkdown/mmark/mast"
+	"github.com/mmarkdown/mmark/v2/mast"
 
 	"github.com/gomarkdown/markdown/ast"
 )

--- a/render/xml/helpers.go
+++ b/render/xml/helpers.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/mmarkdown/mmark/mast"
+	"github.com/mmarkdown/mmark/v2/mast"
 
 	"github.com/gomarkdown/markdown/ast"
 	"github.com/gomarkdown/markdown/html"

--- a/render/xml/renderer.go
+++ b/render/xml/renderer.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/mmarkdown/mmark/mast"
+	"github.com/mmarkdown/mmark/v2/mast"
 
 	"github.com/gomarkdown/markdown/ast"
 	"github.com/gomarkdown/markdown/html"

--- a/render/xml/title.go
+++ b/render/xml/title.go
@@ -10,8 +10,8 @@ import (
 	"github.com/gomarkdown/markdown/ast"
 	"github.com/gomarkdown/markdown/html"
 
-	"github.com/mmarkdown/mmark/mast"
-	"github.com/mmarkdown/mmark/mast/reference"
+	"github.com/mmarkdown/mmark/v2/mast"
+	"github.com/mmarkdown/mmark/v2/mast/reference"
 )
 
 // StatusToCategory translate the status to a category.

--- a/rfc_test.go
+++ b/rfc_test.go
@@ -8,11 +8,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/mmarkdown/mmark/lang"
-	"github.com/mmarkdown/mmark/mast"
-	"github.com/mmarkdown/mmark/mparser"
-	"github.com/mmarkdown/mmark/render/mhtml"
-	"github.com/mmarkdown/mmark/render/xml"
+	"github.com/mmarkdown/mmark/v2/lang"
+	"github.com/mmarkdown/mmark/v2/mast"
+	"github.com/mmarkdown/mmark/v2/mparser"
+	"github.com/mmarkdown/mmark/v2/render/mhtml"
+	"github.com/mmarkdown/mmark/v2/render/xml"
 
 	"github.com/gomarkdown/markdown"
 	"github.com/gomarkdown/markdown/ast"


### PR DESCRIPTION
Because currently using `go install github.com/mmarkdown/mmark@latest` installs `v2.0.40`.

Signed-off-by: Sylvain Rabot <sylvain@abstraction.fr>