### PR TITLE
Remove titleblock's --- trigger

### DIFF
--- a/Syntax.md
+++ b/Syntax.md
@@ -164,9 +164,7 @@ Source code:
 Block Level Attributes:
 :   We use the attributes as specified in RFC 7991, e.g. to specify an empty list style use:
     `{empty="true"}` before the list. The renderer for this output format filters unknown attributes
-    away. The current list is to allow IDs (translated into 'anchor'), remove any `class=` and `style=`
-    attributes, so `{style="empty" empty="true"}`, will make a document both RFC 7991 and RFC 7749
-    compliant.
+    away.
 
 Footnotes:
 :   Are discarded from the final output, don't use them.
@@ -228,26 +226,14 @@ standard](https://tools.ietf.org/html/rfc7991). More on these below. The complet
 specified in [TOML](https://github.com/toml-lang/toml). Examples title blocks can be [found in the
 repository of Mmark](https://github.com/mmarkdown/mmark/tree/master/rfc).
 
-The title block itself needs three or more `%`'s (or `-`'s) at the start and end of the block. A
-minimal title block would look like this:
+The title block itself needs three or more `%`'s at the start and end of the block. A minimal title
+block would look like this:
 
 ~~~
 %%%
 title = "Foo Bar"
 %%%
 ~~~
-or
-
-~~~
----
-title = "Foo Bar"
----
-~~~
-
-The difference between the two is:
-
-* `%%%`: block is assumed to be encoded in TOML and *parsed*.
-* `---`: block is not parsed just outputted as-is again.
 
 #### Elements of the Title Block
 

--- a/mast/title.go
+++ b/mast/title.go
@@ -11,11 +11,10 @@ import (
 type Title struct {
 	ast.Leaf
 	*TitleData
-	Trigger string // either triggered by %%% or ---
 }
 
 // NewTitle returns a pointer to TitleData with some defaults set.
-func NewTitle(trigger byte) *Title {
+func NewTitle() *Title {
 	t := &Title{
 		TitleData: &TitleData{
 			Area:      "Internet",
@@ -23,13 +22,8 @@ func NewTitle(trigger byte) *Title {
 			Consensus: true,
 		},
 	}
-	t.Trigger = string([]byte{trigger, trigger, trigger})
 	return t
 }
-
-const triggerDash = "---"
-
-func (t *Title) IsTriggerDash() bool { return t.Trigger == triggerDash }
 
 // TitleData holds all the elements of the title.
 type TitleData struct {

--- a/mmark.go
+++ b/mmark.go
@@ -94,10 +94,8 @@ func main() {
 			ParserHook: func(data []byte) (ast.Node, []byte, int) {
 				node, data, consumed := mparser.Hook(data)
 				if t, ok := node.(*mast.Title); ok {
-					if !t.IsTriggerDash() {
-						documentTitle = t.TitleData.Title
-						documentLanguage = t.TitleData.Language
-					}
+					documentTitle = t.TitleData.Title
+					documentLanguage = t.TitleData.Language
 				}
 				return node, data, consumed
 			},

--- a/mparser/title.go
+++ b/mparser/title.go
@@ -10,15 +10,15 @@ import (
 )
 
 // TitleHook will parse a title and returns it. The start and ending can
-// be signalled with %%% or --- (the later to more inline with Hugo and other markdown dialects.
+// be signalled with %%%.
 func TitleHook(data []byte) (ast.Node, []byte, int) {
 	i := 0
 	if len(data) < 4 {
 		return nil, nil, 0
 	}
 
-	c := data[i] // first char can either be % or -
-	if c != '%' && c != '-' {
+	c := data[i] // first char must be %
+	if c != '%' {
 		return nil, nil, 0
 	}
 
@@ -41,7 +41,7 @@ func TitleHook(data []byte) (ast.Node, []byte, int) {
 		return nil, nil, 0
 	}
 
-	node := mast.NewTitle(c)
+	node := mast.NewTitle()
 	buf := data[beg:i]
 
 	if c == '-' {

--- a/render/xml/title.go
+++ b/render/xml/title.go
@@ -26,12 +26,6 @@ var StatusToCategory = map[string]string{
 
 func (r *Renderer) titleBlock(w io.Writer, t *mast.Title) {
 	// Order is fixed in RFC 7991.
-
-	if t.IsTriggerDash() {
-		// it was not parsed, leave it alone.
-		return
-	}
-
 	d := t.TitleData
 	if d == nil {
 		return


### PR DESCRIPTION
I believe this was added for markdown output (which is removed, because
buggy). This isn't actuall honored by the current renderers anyway, so
just remove it. Also remove 7449 XML references, as we don't support
that anymore.

Signed-off-by: Miek Gieben <miek@miek.nl>
