### PR TITLE
Fix contacts and normative references

### DIFF
--- a/rfc/1.md
+++ b/rfc/1.md
@@ -8,7 +8,6 @@ submissiontype = "IETF"
 keyword = [""]
 #date = 1969-04-01T00:00:00Z
 
-
 [seriesInfo]
 name = "RFC"
 value = "1"
@@ -19,6 +18,30 @@ status = "informational"
 initials = "S."
 surname = "Crocker"
 fullname = "Steve Crocker"
+organization = "UCLA"
+
+[[contact]]
+initials = "S"
+surname = "Carr"
+fullname = "Steve Carr"
+organization = "Utah"
+
+[[contact]]
+initials = "J"
+surname = "Rulifson"
+fullname = "Jeff Rulifson"
+organization = "SRI"
+
+[[contact]]
+initials = "B"
+Surname = "Duvall"
+Fullname = "Bill Duvall"
+organization = "SRI"
+
+[[contact]]
+initials = "G"
+Surname = "DeLoche"
+Fullname = "Gerard DeLoche"
 organization = "UCLA"
 %%%
 
@@ -32,11 +55,11 @@ HOST software.
 
 During the summer of 1968, representatives from the initial four sites met several times to discuss
 the HOST software and initial experiments on the network. There emerged from these meetings a
-working group of three, Steve Carr from Utah, Jeff Rulifson from SRI, and Steve Crocker of UCLA, who
-met during the fall and winter. The most recent meeting was in the last week of March in Utah. Also
-present was Bill Duvall of SRI who has recently started working with Jeff Rulifson.
+working group of three, [@Steve Carr] from Utah, [@Jeff Rulifson] from SRI, and [@Steve Crocker] of
+UCLA, who met during the fall and winter. The most recent meeting was in the last week of March in
+Utah. Also present was [@Bill Duvall] of SRI who has recently started working with [@Jeff Rulifson].
 
-Somewhat independently, Gerard DeLoche of UCLA has been working on the HOST-IMP interface.
+Somewhat independently, [@Gerard DeLoche] of UCLA has been working on the HOST-IMP interface.
 
 I present here some of the tentative agreements reached and some of the open questions encountered.
 Very little of what is here is firm and reactions are expected.


### PR DESCRIPTION
Make the names in rfc/1.md proper contacts and found it also created a
normative references section. This is because we don't filter
authors/contact from the reference list and hence they get outputted
there.

Fix this to check for authors and contact when gathering the informative
references.

Signed-off-by: Miek Gieben <miek@miek.nl>
