### PR TITLE
Fix NAME section in mmark.1 so it can be parsed correctly

### DIFF
--- a/mmark.1
+++ b/mmark.1
@@ -3,7 +3,7 @@
 
 .SH "NAME"
 .PP
-mmark – generate XML, HTML or markdown from mmark markdown documents.
+mmark \- generate XML, HTML or markdown from mmark markdown documents.
 
 .SH "SYNOPSIS"
 .PP

--- a/mmark.1.md
+++ b/mmark.1.md
@@ -7,7 +7,7 @@ date: October 2019
 
 # NAME
 
-mmark – generate XML, HTML or markdown from mmark markdown documents.
+mmark \\- generate XML, HTML or markdown from mmark markdown documents.
 
 # SYNOPSIS
 


### PR DESCRIPTION
Replace en dash (U+2013) with `\-` so the NAME section can be parsed
correctly by lexgrog for query by apropos and whatis.

Fixes Lintian "bad-whatis-entry" warning:

```
W: mmark: bad-whatis-entry [usr/share/man/man1/mmark.1.gz]
N:
N:   A manual page should start with a NAME section, which lists the program
N:   name and a brief description. The NAME section is used to generate a
N:   database that can be queried by commands like apropos and whatis. You are
N:   seeing this tag because lexgrog was unable to parse the NAME section.
N:
N:   Manual pages for multiple programs, functions, or files should list each
N:   separated by a comma and a space, followed by \- and a common description.
N:
N:   Listed items may not contain any spaces. A manual page for a two-level
N:   command such as fs listacl must look like fs_listacl so the list is read
N:   correctly.
N:
N:   Please refer to the lexgrog(1) manual page, the groff_man(7) manual page,
N:   and the groff_mdoc(7) manual page for details.
```

This Lintian warning was noticed when packaging mmark (v2) for Debian (see <https://bugs.debian.org/916202>).