### PR TITLE
Use CDATA for codeblocks

### DIFF
--- a/render/xml/callouts.go
+++ b/render/xml/callouts.go
@@ -39,3 +39,25 @@ Parse:
 		}
 	}
 }
+
+// Check for callouts in the buffer.
+func callouts(d []byte, comments [][]byte) bool {
+	ld := len(d)
+
+	for i := 0; i < ld; i++ {
+		for _, comment := range comments {
+			if !bytes.HasPrefix(d[i:], comment) {
+				break
+			}
+
+			lc := len(comment)
+			if i+lc < ld {
+				if _, consumed := parser.IsCallout(d[i+lc:]); consumed > 0 {
+					// We have seen a callout
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/render/xml/renderer.go
+++ b/render/xml/renderer.go
@@ -501,10 +501,16 @@ func (r *Renderer) codeBlock(w io.Writer, codeBlock *ast.CodeBlock) {
 
 	r.cr(w)
 	r.outTag(w, "<"+name, html.BlockAttrs(codeBlock))
+	callout := false
 	if r.opts.Comments != nil {
+		callout = callouts(codeBlock.Literal, r.opts.Comments)
+	}
+	if callout {
 		EscapeHTMLCallouts(w, codeBlock.Literal, r.opts.Comments)
 	} else {
-		html.EscapeHTML(w, codeBlock.Literal)
+		r.outs(w, "<![CDATA[")
+		r.out(w, codeBlock.Literal)
+		r.outs(w, "]]>\n")
 	}
 	r.outs(w, "</"+name+">")
 	r.cr(w)

--- a/testdata/artwork.xml
+++ b/testdata/artwork.xml
@@ -1,2 +1,3 @@
-<artwork>println(&quot;hello&quot;)
+[<artwork><![CDATA[println("hello")
+]]>
 </artwork>

--- a/testdata/artwork.xml
+++ b/testdata/artwork.xml
@@ -1,3 +1,3 @@
-[<artwork><![CDATA[println("hello")
+<artwork><![CDATA[println("hello")
 ]]>
 </artwork>

--- a/testdata/code-caption-id.xml
+++ b/testdata/code-caption-id.xml
@@ -1,5 +1,5 @@
 <figure anchor="golang"><name>This is a proper caption. </name>
-<artwork>println(&quot;GO&quot;)
+<artwork><![CDATA[println("GO")
+]]>
 </artwork>
 </figure>
-

--- a/testdata/figure-anchor.xml
+++ b/testdata/figure-anchor.xml
@@ -1,10 +1,11 @@
 <figure anchor="fig-scenic-routing-option-layout"><name>Scenic Routing Option Layout</name>
-<artwork> 0                   1                   2                   3
+<artwork><![CDATA[ 0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
                                 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
                                 |  Option Type  | Option Length |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |   SRO Param   |                                               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+]]>
 </artwork>
 </figure>

--- a/testdata/include-block-caption.xml
+++ b/testdata/include-block-caption.xml
@@ -1,8 +1,9 @@
 <figure><name>A sample function.
 </name>
-<sourcecode type="c">main() int {
+<sourcecode type="c"><![CDATA[main() int {
         return 0
 }
+]]>
 </sourcecode>
 </figure>
 <t>And some other text.</t>

--- a/testdata/include-block.xml
+++ b/testdata/include-block.xml
@@ -1,5 +1,6 @@
-<sourcecode type="c">main() int {
+<sourcecode type="c"><![CDATA[main() int {
         return 0
 }
+]]>
 </sourcecode>
 <t>And some other text.</t>

--- a/testdata/sourcecode.xml
+++ b/testdata/sourcecode.xml
@@ -1,2 +1,3 @@
-<sourcecode type="go">println(&quot;hello&quot;)
+<sourcecode type="go"><![CDATA[println("hello")
+]]>
 </sourcecode>

--- a/testdata/table-codeblock.xml
+++ b/testdata/table-codeblock.xml
@@ -14,5 +14,6 @@
 </tr>
 </tbody>
 </table>
-<sourcecode type="sh">% cat /dev/zero
+<sourcecode type="sh"><![CDATA[% cat /dev/zero
+]]>
 </sourcecode>


### PR DESCRIPTION
When no callouts are used, put then entire blob in a CDATA. This (at
least) allows easy extraction of data from the generated XML.

Signed-off-by: Miek Gieben <miek@miek.nl>
