### PR TITLE
Add `sortRefs` attribute for `<rfc>` block

### DIFF
--- a/mast/title.go
+++ b/mast/title.go
@@ -21,6 +21,7 @@ func NewTitle() *Title {
 			Ipr:          "trust200902",
 			Consensus:    true,
 			IndexInclude: true,
+			SortRefs:     false,
 		},
 	}
 	return t
@@ -34,6 +35,7 @@ type TitleData struct {
 	SeriesInfo     reference.SeriesInfo
 	IndexInclude   bool
 	Consensus      bool
+	SortRefs       bool
 	TocDepth       int
 	Ipr            string // See https://tools.ietf.org/html/rfc7991#appendix-A.1
 	Obsoletes      []int

--- a/render/xml/title.go
+++ b/render/xml/title.go
@@ -50,6 +50,13 @@ func (r *Renderer) titleBlock(w io.Writer, t *mast.Title) {
 			[]string{fmt.Sprintf("%t", d.Consensus)},
 		)...)
 	}
+	// RFC 7991 Section 2.45.11: Default is false.
+	if d.SortRefs {
+		attrs = append(attrs, Attributes(
+			[]string{"sortRefs"},
+			[]string{fmt.Sprintf("%t", d.SortRefs)},
+		)...)
+	}
 	if t.TocDepth > 0 {
 		attrs = append(attrs, Attributes(
 			[]string{"tocDepth"},


### PR DESCRIPTION
Part of mmarkdown/mmark#198.