### PR TITLE
Fix citation of drafts

### DIFF
--- a/Syntax.md
+++ b/Syntax.md
@@ -584,7 +584,8 @@ reference section.
 For I-Ds you may want to add a draft sequence number, which can be done as such: `[@?I-D.blah#06]`.
 If you reference an I-D *without* a sequence number it will create a reference to the *last* I-D in
 citation index. I.e. a draft named "draft-gieben-pandoc2rfc", the I-D reference becomes:
-`I-D.gieben-pandoc2rfc`.
+`I-D.gieben-pandoc2rfc`. Referencing multiple versions of the same I-D in a document will lead to
+validation errors when running xml2rfc.
 
 A bibliography section is created by default if a `{backmatter}` is given, but you can suppress it
 by using the command line flag `-bibliography=false`. No `{backmatter}`, no bibliography.

--- a/render/xml/bibliography.go
+++ b/render/xml/bibliography.go
@@ -70,12 +70,22 @@ func (r *Renderer) bibliographyItem(w io.Writer, node *mast.BibliographyItem) {
 
 	case bytes.HasPrefix(node.Anchor, []byte("I-D.")):
 		hash := bytes.Index(node.Anchor, []byte("#"))
+		draft := ""
 		if hash > 0 {
-			// rewrite # to - and we have our link
+			// no version: https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.brzozowski-dhc-dhcvp6-leasequery.xml
+			//
+			// with version: https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.draft-brzozowski-dhc-dhcvp6-leasequery-00.xml
+			//
+			// rewrite # to - and we have our link, and also include "draft-" before for it xi:include
+			// the anchor text from the reference is: anchor="I-D.brzozowski-dhc-dhcvp6-leasequery"
+			// problem here is that the original xref includes #00, which isn't the case in the reference
+			// any more.
+
+			draft = "draft-"
 			node.Anchor[hash] = '-'
-			defer func() { node.Anchor[hash] = '#' }() // never know if this will be used again
+			//defer func() { node.Anchor[hash] = '#' }() // never know if this will be used again
 		}
-		tag = makeXiInclude(BibID, fmt.Sprintf("reference.I-D.%s.xml", node.Anchor[4:]))
+		tag = makeXiInclude(BibID, fmt.Sprintf("reference.I-D.%s%s.xml", draft, node.Anchor[4:]))
 	}
 	r.outs(w, tag)
 	r.cr(w)

--- a/render/xml/bibliography.go
+++ b/render/xml/bibliography.go
@@ -83,7 +83,7 @@ func (r *Renderer) bibliographyItem(w io.Writer, node *mast.BibliographyItem) {
 
 			draft = "draft-"
 			node.Anchor[hash] = '-'
-			//defer func() { node.Anchor[hash] = '#' }() // never know if this will be used again
+			defer func() { node.Anchor[hash] = '#' }() // never know if this will be used again
 		}
 		tag = makeXiInclude(BibID, fmt.Sprintf("reference.I-D.%s%s.xml", draft, node.Anchor[4:]))
 	}

--- a/render/xml/renderer.go
+++ b/render/xml/renderer.go
@@ -256,9 +256,7 @@ func (r *Renderer) citation(w io.Writer, node *ast.Citation, entering bool) {
 			continue
 		}
 
-		// draft-referencing, if there is a #00 (#version) we remove it from the target, but save
-		// the number as the first word in the Suffix to pick it up later when we generate the URL
-		// for the xi:include
+		// draft-referencing, if there is a #00 (#version) we remove it from the target as this isn't allowed.
 		if bytes.HasPrefix(c, []byte("I-D.")) {
 			hash := bytes.Index(c, []byte("#"))
 			if hash > 0 {

--- a/render/xml/renderer.go
+++ b/render/xml/renderer.go
@@ -256,6 +256,16 @@ func (r *Renderer) citation(w io.Writer, node *ast.Citation, entering bool) {
 			continue
 		}
 
+		// draft-referencing, if there is a #00 (#version) we remove it from the target, but save
+		// the number as the first word in the Suffix to pick it up later when we generate the URL
+		// for the xi:include
+		if bytes.HasPrefix(c, []byte("I-D.")) {
+			hash := bytes.Index(c, []byte("#"))
+			if hash > 0 {
+				c = c[:hash]
+			}
+		}
+
 		attr := []string{fmt.Sprintf(`target="%s"`, c)}
 
 		// Attempt to parse the suffix.

--- a/rfc/draft-citation-test.md
+++ b/rfc/draft-citation-test.md
@@ -1,0 +1,34 @@
+%%%
+title = "Citation test"
+abbrev = "test"
+ipr = "trust200902"
+area = "Internet"
+workgroup = "Network Working Group"
+submissiontype = "IETF"
+keyword = [""]
+
+[seriesInfo]
+name = "RFC"
+value = "2100"
+stream = "IETF"
+status = "informational"
+
+[[author]]
+initials="R."
+surname="Gieben"
+fullname="Miek (R.) Gieben"
+  [author.address]
+  email = "miek@miek.nl"
+%%%
+
+{mainmatter}
+
+# Introduction
+
+Citation test.
+
+[@?I-D.muks-dnsop-dns-squash#00]
+
+[@?I-D.brzozowski-dhc-dhcvp6-leasequery]
+
+{backmatter}

--- a/rfc_test.go
+++ b/rfc_test.go
@@ -26,6 +26,8 @@ var (
 		"5841.md",
 		"7511.md",
 		"8341.md",
+		//
+		"draft-citation-test.md",
 	}
 )
 


### PR DESCRIPTION
This fixes the citation of drafts, which is (somehow) made complex. If
the no version is given you get the latest. If you do give a version you
get *that* version. However the xref target may not include the version
and the URL of the xi:include is different depending if the version if
given or not.

Add draft-citation-test.md file to (locally) test if this all works.

Really fixes: #195

Closes: #195

Signed-off-by: Miek Gieben <miek@miek.nl>
