### PR TITLE
Remove `relative="#"` attribute from section citations

### DIFF
--- a/render/xml/renderer.go
+++ b/render/xml/renderer.go
@@ -276,21 +276,21 @@ func (r *Renderer) citation(w io.Writer, node *ast.Citation, entering bool) {
 				switch {
 				case bytes.HasPrefix(suf, []byte(section)):
 					num := suf[len(section):]
-					attr = append(attr, `sectionFormat="of" relative="#"`)
+					attr = append(attr, `sectionFormat="of"`)
 					attr = append(attr, `section="`+string(num)+`"`)
 
 				case bytes.HasPrefix(suf, []byte(seesection)):
 					num := suf[len(seesection):]
-					attr = append(attr, `sectionFormat="comma" relative="#"`)
+					attr = append(attr, `sectionFormat="comma"`)
 					attr = append(attr, `section="`+string(num)+`"`)
 
 				case bytes.HasPrefix(suf, []byte(seepsection)):
 					num := suf[len(seepsection):]
-					attr = append(attr, `sectionFormat="parens" relative="#"`)
+					attr = append(attr, `sectionFormat="parens"`)
 					attr = append(attr, `section="`+string(num)+`"`)
 
 				default:
-					attr = append(attr, `sectionFormat="bare" relative="#"`)
+					attr = append(attr, `sectionFormat="bare"`)
 					attr = append(attr, `section="`+string(suf)+`"`)
 				}
 			}

--- a/testdata/citation1.xml
+++ b/testdata/citation1.xml
@@ -1,1 +1,1 @@
-<t><xref target="RFC2535" sectionFormat="of" relative="#" section="5"></xref></t>
+<t><xref target="RFC2535" sectionFormat="of" section="5"></xref></t>

--- a/testdata/citation2.xml
+++ b/testdata/citation2.xml
@@ -1,1 +1,1 @@
-<t><xref target="RFC2535" sectionFormat="comma" relative="#" section="5"></xref><xref target="RFC2523"></xref></t>
+<t><xref target="RFC2535" sectionFormat="comma" section="5"></xref><xref target="RFC2523"></xref></t>

--- a/testdata/citation3.xml
+++ b/testdata/citation3.xml
@@ -1,1 +1,1 @@
-<t><xref target="RFC2535" sectionFormat="bare" relative="#" section="5"></xref><xref target="RFC2535" sectionFormat="bare" relative="#" section="6"></xref></t>
+<t><xref target="RFC2535" sectionFormat="bare" section="5"></xref><xref target="RFC2535" sectionFormat="bare" section="6"></xref></t>

--- a/testdata/citation5.xml
+++ b/testdata/citation5.xml
@@ -1,1 +1,1 @@
-<t><xref target="RFC2535" sectionFormat="parens" relative="#" section="5"></xref></t>
+<t><xref target="RFC2535" sectionFormat="parens" section="5"></xref></t>

--- a/testdata/nl_citation1.xml
+++ b/testdata/nl_citation1.xml
@@ -1,1 +1,1 @@
-<t><xref target="RFC2535" sectionFormat="of" relative="#" section="5"></xref></t>
+<t><xref target="RFC2535" sectionFormat="of" section="5"></xref></t>

--- a/testdata/nl_citation2.xml
+++ b/testdata/nl_citation2.xml
@@ -1,1 +1,1 @@
-<t><xref target="RFC2535" sectionFormat="comma" relative="#" section="5"></xref><xref target="RFC2523"></xref></t>
+<t><xref target="RFC2535" sectionFormat="comma" section="5"></xref><xref target="RFC2523"></xref></t>


### PR DESCRIPTION
This ensures that section reference URLs link directly to the referenced section, instead of the top-level document.

Closes mmarkdown/mmark#205.