### PR TITLE
ci: set up GoReleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.3
+      - uses: goreleaser/goreleaser-action@v5
+        with:
+          version: v1.21.2
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: |
-            Release version ${{ github.ref }}
-          draft: false
-          prerelease: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 mmark
 build
 release
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,22 @@
+project_name: mmark
+
+builds:
+  - goarch:
+      - amd64
+      - arm
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+      - goos: darwin
+        goarch: arm
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{ .Arch }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,7 +14,7 @@ builds:
         goarch: arm
 
 archives:
-  - format: tar.gz
+  - format: tgz
     name_template: >-
       {{ .ProjectName }}_
       {{- .Version }}_

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,4 +19,4 @@ archives:
       {{ .ProjectName }}_
       {{- .Version }}_
       {{- .Os }}_
-      {{ .Arch }}
+      {{- .Arch }}


### PR DESCRIPTION
Close https://github.com/mmarkdown/mmark/issues/207

Build and release prebuilt binaries automatically with GoReleaser by CI.

- Configure GoReleaser
- Set up GitHub Actions Workflow to run GoReleaser

I ran the workflow in my fork repository for testing, and confirmed it works well.

https://github.com/suzuki-shunsuke/mmark/releases/tag/v0.1.0-3
https://github.com/suzuki-shunsuke/mmark/actions/runs/6677329544/job/18147246647

```
mmark_0.1.0-3_checksums.txt
mmark_0.1.0-3_darwin_amd64.tgz
mmark_0.1.0-3_darwin_arm64.tgz
mmark_0.1.0-3_linux_amd64.tgz
mmark_0.1.0-3_linux_arm.tgz
mmark_0.1.0-3_linux_arm64.tgz
mmark_0.1.0-3_windows_amd64.tgz
```

```console
$ tar ztvf mmark_0.1.0-3_darwin_amd64.tgz 
-rw-r--r--  0 runner docker   1362 10 28 22:56 LICENSE
-rw-r--r--  0 runner docker   4595 10 28 22:56 README.md
-rwxr-xr-x  0 runner docker 2978160 10 28 22:57 mmark
```

Asset names, supported platforms, and the structure of archives keep the compatibility with those of previous versions.

https://github.com/mmarkdown/mmark/releases/tag/v2.2.31

```
mmark_2.2.31_darwin_amd64.tgz
mmark_2.2.31_darwin_arm64.tgz
mmark_2.2.31_linux_amd64.tgz
mmark_2.2.31_linux_arm.tgz
mmark_2.2.31_linux_arm64.tgz
mmark_2.2.31_windows_amd64.tgz
```

```console
$ tar ztvf mmark_2.2.31_darwin_amd64.tgz 
-rwxrwxr-x  0 miek   miek  4006960  2  8  2023 mmark
```