### PR TITLE
Set `fetch-depth: 0` for `actions/checkout` in `CI` pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - run: git fetch --force --tags
       - uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
This should add the missing changelog. Seems like a `fetch-depth` of 0 needs to be set for the action to work properly. This is mentioned [here](https://goreleaser.com/ci/actions/#workflow) in the docs for the `goreleaser-action`.

I setup a little test repo to test these changes out. Feel free to take a look:
[CI workflow file](https://github.com/qasimwarraich/goreleaser-test/blob/main/.github/workflows/ci.yml#L18-L19)
[Releases w/ changelog](https://github.com/qasimwarraich/goreleaser-test/releases)


Resolves: #217 