### PR TITLE
Add simple Docker image & Docker CI/CD

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -35,4 +35,6 @@ jobs:
         file: Dockerfile
         platforms: linux/amd64,linux/arm64
         push: true
-        tags: ghcr.io/daniel-dewa/mmark:latest
+        tags: |
+          ghcr.io/daniel-dewa/mmark:latest
+          ghcr.io/daniel-dewa/mmark:${{ github.ref_name }}

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,0 +1,42 @@
+name: Build Docker Images
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'Dockerfile'
+
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Base image - Docker Build & Push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ghcr.io/daniel-dewa/mmark:latest

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -36,5 +36,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/daniel-dewa/mmark:latest
-          ghcr.io/daniel-dewa/mmark:${{ github.ref_name }}
+          ghcr.io/mmarkdown/mmark:latest
+          ghcr.io/mmarkdown/mmark:${{ github.ref_name }}

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -2,12 +2,8 @@ name: Build Docker Images
 
 on:
   push:
-    branches:
-      - 'main'
-    paths:
-      - 'Dockerfile'
-
-  workflow_dispatch:
+    tags:
+      - 'v*'
 
 jobs:
   publish:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+
+# Build the application from source
+FROM golang:1.25 AS build-stage
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY *.go ./
+COPY lang/ lang/
+COPY mast/ mast/
+COPY mparser/ mparser/
+COPY render/ render/
+COPY rfc/ rfc/
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o /mmark
+
+# Run the tests in the container
+FROM build-stage AS run-test-stage
+RUN go test -v ./...
+
+# Deploy the application binary into a lean image
+FROM gcr.io/distroless/base-debian13 AS build-release-stage
+
+WORKDIR /
+
+COPY --from=build-stage /mmark /mmark
+
+WORKDIR /data
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/mmark"]

--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ The image can be used as in the following example:
 ```sh
 docker run --rm `# automatically remove container upon termination` \
   -v "$(pwd):/data" `# bind current working directory to /data` \
-  ghcr.io/daniel-dewa/mmark:latest `# container name` \
+  ghcr.io/mmarkdown/mmark:latest `# container name` \
   example.md > example.xml # example.md input filename, pipe output to example.xml
 
 # single-line
-docker run --rm -v $(pwd):/data ghcr.io/daniel-dewa/mmark:latest example.md > example.xml
+docker run --rm -v $(pwd):/data ghcr.io/mmarkdown/mmark:latest example.md > example.xml
 ```
 
 ## Example RFC

--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ right. This may result in invalid XML. Any warning from `mmark` are send to stan
 and check for those you can discard standard output to just leave standard error: `./mmark
 rfc/3515.md > /dev/null`.
 
+### Docker
+
+A container image is automatically built on every release and is available from the GitHub Container Registry.
+The image can be used as in the following example:
+
+```sh
+docker run --rm `# automatically remove container upon termination` \
+  -v "$(pwd):/data" `# bind current working directory to /data` \
+  ghcr.io/daniel-dewa/mmark:latest `# container name` \
+  example.md > example.xml # example.md input filename, pipe output to example.xml
+
+# single-line
+docker run --rm -v $(pwd):/data ghcr.io/daniel-dewa/mmark:latest example.md > example.xml
+```
+
 ## Example RFC
 
 The rfc/ directory contains a couple of example RFCs that can be build via v3 tool chain.


### PR DESCRIPTION
Multiple specs from Oidf use an unofficial wrapper in CI/CD draft workflows.
Why not add an official Docker image hosted on GitHub Container Registry?

Changes:
- Dockerfile
- ci-docker.yml workflow
- Docker image usage instructions in README